### PR TITLE
fix: add fetch-depth to checkout for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          fetch-depth: 0
 
       - name: Use Node 18
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
  - Fix semantic-release failing with "local branch is behind remote" error

  ## Problem
  The release workflow was failing because `actions/checkout@v4` defaults to a shallow clone (`fetch-depth: 1`), which only fetches the latest commit.
  Semantic-release requires the full git history to properly compare branches and determine version bumps.

  ## Solution
  Added `fetch-depth: 0` to fetch the complete git history during checkout.