### PR TITLE
feat: Adding package-json option for reactors and proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@basis-theory/node-sdk": "5.0.0",
+    "@basis-theory/node-sdk": "^5.2.0",
     "@inquirer/checkbox": "^1.5.0",
     "@inquirer/confirm": "^2.0.15",
     "@inquirer/input": "^1.2.14",

--- a/src/commands/proxies/create.ts
+++ b/src/commands/proxies/create.ts
@@ -51,14 +51,14 @@ export default class Create extends BaseCommand {
         '--request-transform-timeout 10 ' +
         '--request-transform-warm-concurrency 0 ' +
         '--request-transform-resources standard ' +
-        '--request-transform-dependencies ./deps.json ' +
+        '--request-transform-package-json ./request/package.json ' +
         '--request-transform-permissions token:read ' +
         '--response-transform-code ./response.js ' +
         '--response-transform-image node22 ' +
         '--response-transform-timeout 10 ' +
         '--response-transform-warm-concurrency 0 ' +
         '--response-transform-resources standard ' +
-        '--response-transform-dependencies ./deps.json ' +
+        '--response-transform-package-json ./response/package.json ' +
         '--response-transform-permissions token:read',
     },
   ];

--- a/src/commands/proxies/update.ts
+++ b/src/commands/proxies/update.ts
@@ -46,14 +46,14 @@ export default class Update extends BaseCommand {
         '--request-transform-timeout 10 ' +
         '--request-transform-warm-concurrency 0 ' +
         '--request-transform-resources standard ' +
-        '--request-transform-dependencies ./deps.json ' +
+        '--request-transform-package-json ./request/package.json ' +
         '--request-transform-permissions token:read ' +
         '--response-transform-code ./response.js ' +
         '--response-transform-image node22 ' +
         '--response-transform-timeout 10 ' +
         '--response-transform-warm-concurrency 0 ' +
         '--response-transform-resources standard ' +
-        '--response-transform-dependencies ./deps.json ' +
+        '--response-transform-package-json ./response/package.json ' +
         '--response-transform-permissions token:read',
     },
   ];
@@ -98,13 +98,13 @@ export default class Update extends BaseCommand {
       configuration,
       'require-auth': requireAuth,
       'request-transform-image': requestTransformImage,
-      'request-transform-dependencies': requestTransformDependencies,
+      'request-transform-package-json': requestTransformPackageJson,
       'request-transform-timeout': requestTransformTimeout,
       'request-transform-warm-concurrency': requestTransformWarmConcurrency,
       'request-transform-resources': requestTransformResources,
       'request-transform-permissions': requestTransformPermissions,
       'response-transform-image': responseTransformImage,
-      'response-transform-dependencies': responseTransformDependencies,
+      'response-transform-package-json': responseTransformPackageJson,
       'response-transform-timeout': responseTransformTimeout,
       'response-transform-warm-concurrency': responseTransformWarmConcurrency,
       'response-transform-resources': responseTransformResources,
@@ -118,7 +118,7 @@ export default class Update extends BaseCommand {
 
     const requestTransformRuntime = buildRuntime({
       image: requestTransformImage,
-      dependencies: requestTransformDependencies,
+      packageJson: requestTransformPackageJson,
       timeout: requestTransformTimeout,
       warmConcurrency: requestTransformWarmConcurrency,
       resources: requestTransformResources,
@@ -127,7 +127,7 @@ export default class Update extends BaseCommand {
 
     const responseTransformRuntime = buildRuntime({
       image: responseTransformImage,
-      dependencies: responseTransformDependencies,
+      packageJson: responseTransformPackageJson,
       timeout: responseTransformTimeout,
       warmConcurrency: responseTransformWarmConcurrency,
       resources: responseTransformResources,

--- a/src/commands/reactors/create.ts
+++ b/src/commands/reactors/create.ts
@@ -40,7 +40,7 @@ export default class Create extends BaseCommand {
         '--timeout 10 ' +
         '--warm-concurrency 0 ' +
         '--resources standard ' +
-        '--dependencies ./deps.json ' +
+        '--package-json ./package.json ' +
         '--permissions token:read ' +
         '--permissions token:create',
     },
@@ -57,7 +57,7 @@ export default class Create extends BaseCommand {
       timeout,
       'warm-concurrency': warmConcurrency,
       resources,
-      dependencies,
+      'package-json': packageJson,
       permissions,
       'application-id': applicationId,
       async: asyncFlag,
@@ -97,7 +97,7 @@ export default class Create extends BaseCommand {
         timeout,
         'warm-concurrency': warmConcurrency,
         resources,
-        dependencies,
+        'package-json': packageJson,
         permissions,
       });
 

--- a/src/commands/reactors/update.ts
+++ b/src/commands/reactors/update.ts
@@ -38,7 +38,7 @@ export default class Update extends BaseCommand {
         '--timeout 10 ' +
         '--warm-concurrency 0 ' +
         '--resources standard ' +
-        '--dependencies ./deps.json ' +
+        '--package-json ./package.json ' +
         '--permissions token:read ' +
         '--permissions token:create',
     },
@@ -80,7 +80,7 @@ export default class Update extends BaseCommand {
       'application-id': applicationId,
       configuration,
       image,
-      dependencies,
+      'package-json': packageJson,
       timeout,
       'warm-concurrency': warmConcurrency,
       resources,
@@ -94,7 +94,7 @@ export default class Update extends BaseCommand {
 
     const runtime = buildRuntime({
       image,
-      dependencies,
+      packageJson,
       timeout,
       warmConcurrency,
       resources,

--- a/src/proxies/runtime.ts
+++ b/src/proxies/runtime.ts
@@ -99,7 +99,7 @@ const promptTransformRuntime = async (
       | number
       | undefined,
     resources: flags[`${prefix}-transform-resources`] as string | undefined,
-    dependencies: flags[`${prefix}-transform-dependencies`] as
+    'package-json': flags[`${prefix}-transform-package-json`] as
       | string
       | undefined,
     permissions: flags[`${prefix}-transform-permissions`] as

--- a/src/proxies/utils.ts
+++ b/src/proxies/utils.ts
@@ -42,9 +42,9 @@ const PROXY_FLAGS = {
     )})`,
     options: [...VALID_RUNTIME_IMAGES],
   }),
-  'request-transform-dependencies': Flags.file({
+  'request-transform-package-json': Flags.file({
     description:
-      'path to JSON file with npm dependencies, e.g. {"axios": "1.7.9", "lodash": "4.17.21"} (node22 only)',
+      'path to runtime package.json JSON file (top-level dependencies required; supports resolutions or overrides fallback; pinned versions required) (node22 only)',
   }),
   'request-transform-timeout': Flags.integer({
     description: 'request-transform timeout in seconds, 1-30 (node22 only)',
@@ -71,9 +71,9 @@ const PROXY_FLAGS = {
     )})`,
     options: [...VALID_RUNTIME_IMAGES],
   }),
-  'response-transform-dependencies': Flags.file({
+  'response-transform-package-json': Flags.file({
     description:
-      'path to JSON file with npm dependencies, e.g. {"axios": "1.7.9", "lodash": "4.17.21"} (node22 only)',
+      'path to runtime package.json JSON file (top-level dependencies required; supports resolutions or overrides fallback; pinned versions required) (node22 only)',
   }),
   'response-transform-timeout': Flags.integer({
     description: 'response-transform timeout in seconds, 1-30 (node22 only)',

--- a/src/runtime/flags.ts
+++ b/src/runtime/flags.ts
@@ -6,9 +6,9 @@ const RUNTIME_FLAGS = {
     description: `runtime image (${VALID_RUNTIME_IMAGES.join('|')})`,
     options: [...VALID_RUNTIME_IMAGES],
   }),
-  dependencies: Flags.file({
+  'package-json': Flags.file({
     description:
-      'path to JSON file with npm dependencies, e.g. {"axios": "1.7.9", "lodash": "4.17.21"} (node22 only)',
+      'path to runtime package.json JSON file (top-level dependencies required; supports resolutions or overrides fallback; pinned versions required) (node22 only)',
   }),
   timeout: Flags.integer({
     description: 'timeout in seconds, 1-30 (node22 only, default: 10)',

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -5,6 +5,7 @@ export {
   CONFIGURABLE_RUNTIME_FLAGS,
   isLegacyRuntimeImage,
   validateRuntimeImage,
+  parseRuntimePackageJsonFile,
   buildRuntime,
   promptRuntimeOptions,
   promptRuntimeImage,

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -4,6 +4,26 @@ import { ux } from '@oclif/core';
 const POLL_INTERVAL = 2000; // 2 seconds
 const POLL_TIMEOUT = 600000; // 10 minutes
 
+const formatErrorDetails = (value: unknown): string => {
+  if (typeof value === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(value), undefined, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  if (typeof value === 'object' && Boolean(value)) {
+    try {
+      return JSON.stringify(value, undefined, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+};
+
 const formatErrorMessage = (
   resource: BasisTheory.Reactor | BasisTheory.Proxy,
   resourceType: 'reactor' | 'proxy'
@@ -21,7 +41,7 @@ const formatErrorMessage = (
   }
 
   if (requested?.errorDetails) {
-    parts.push(`errorDetails: ${JSON.stringify(requested.errorDetails)}`);
+    parts.push(`errorDetails: ${formatErrorDetails(requested.errorDetails)}`);
   }
 
   return parts.join('\n');

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -42,12 +42,12 @@ const CONFIGURABLE_RUNTIME_FLAGS = [
   'resources',
   'warm-concurrency',
   'permissions',
-  'dependencies',
+  'package-json',
 ] as const;
 
 interface RuntimeFlagProps {
   image?: string;
-  dependencies?: string; // path to JSON file
+  packageJson?: string; // path to runtime package.json file
   timeout?: number;
   warmConcurrency?: number;
   resources?: string;
@@ -59,7 +59,7 @@ interface RuntimeFlags {
   timeout?: number;
   'warm-concurrency'?: number;
   resources?: string;
-  dependencies?: string;
+  'package-json'?: string;
   permissions?: string[];
 }
 
@@ -67,16 +67,89 @@ interface ConfigurableRuntimeOptions {
   timeout?: number;
   warmConcurrency?: number;
   resources?: string;
-  dependencies?: string;
+  packageJson?: string;
   permissions?: string[];
 }
+
+interface ParsedRuntimePackageFile {
+  dependencies: Record<string, string>;
+  resolutions?: Record<string, string>;
+}
+
+const isStringRecord = (value: unknown): value is Record<string, string> =>
+  typeof value === 'object' &&
+  Boolean(value) &&
+  !Array.isArray(value) &&
+  Object.values(value as Record<string, unknown>).every(
+    (item) => typeof item === 'string'
+  );
+
+const parseRuntimePackageJsonFile = (
+  packageJsonPath: string
+): ParsedRuntimePackageFile => {
+  let parsedFile: unknown;
+
+  try {
+    parsedFile = JSON.parse(readFileContents(packageJsonPath));
+  } catch (error) {
+    throw new Error(
+      `Failed to parse package.json file "${packageJsonPath}": ${
+        (error as Error).message
+      }`
+    );
+  }
+
+  if (
+    !parsedFile ||
+    typeof parsedFile !== 'object' ||
+    Array.isArray(parsedFile)
+  ) {
+    throw new Error(
+      `Runtime package file "${packageJsonPath}" must include a top-level "dependencies" object.`
+    );
+  }
+
+  const file = parsedFile as Record<string, unknown>;
+  const dependencies = file.dependencies;
+
+  if (!isStringRecord(dependencies)) {
+    throw new Error(
+      `Runtime package file "${packageJsonPath}" has invalid "dependencies": expected an object of package names to pinned version strings.`
+    );
+  }
+
+  let resolutions: Record<string, string> | undefined;
+
+  if (file.resolutions !== undefined) {
+    if (!isStringRecord(file.resolutions)) {
+      throw new Error(
+        `Runtime package file "${packageJsonPath}" has invalid "resolutions": expected an object of package names to pinned version strings.`
+      );
+    }
+
+    resolutions = file.resolutions;
+  } else if (file.overrides !== undefined) {
+    if (!isStringRecord(file.overrides)) {
+      throw new Error(
+        `Runtime package file "${packageJsonPath}" has unsupported "overrides" values for runtime resolutions; only string values are supported.`
+      );
+    }
+
+    resolutions = file.overrides;
+  }
+
+  return {
+    dependencies,
+    resolutions,
+  };
+};
 
 const buildRuntime = (
   props: RuntimeFlagProps
 ): BasisTheory.Runtime | undefined => {
   const {
     image,
-    dependencies,
+    packageJson,
     timeout,
     warmConcurrency,
     resources,
@@ -85,7 +158,7 @@ const buildRuntime = (
 
   if (
     !image &&
-    !dependencies &&
+    !packageJson &&
     !timeout &&
     !warmConcurrency &&
     !resources &&
@@ -94,18 +167,10 @@ const buildRuntime = (
     return undefined;
   }
 
-  let parsedDependencies: Record<string, string> | undefined;
+  let parsedPackageFile: ParsedRuntimePackageFile | undefined;
 
-  if (dependencies) {
-    try {
-      parsedDependencies = JSON.parse(readFileContents(dependencies));
-    } catch (error) {
-      throw new Error(
-        `Failed to parse dependencies file "${dependencies}": ${
-          (error as Error).message
-        }`
-      );
-    }
+  if (packageJson) {
+    parsedPackageFile = parseRuntimePackageJsonFile(packageJson);
   }
 
   const runtime: BasisTheory.Runtime = {};
@@ -114,8 +179,16 @@ const buildRuntime = (
     runtime.image = image;
   }
 
-  if (parsedDependencies) {
-    runtime.dependencies = parsedDependencies;
+  if (parsedPackageFile) {
+    runtime.dependencies = parsedPackageFile.dependencies;
+  }
+
+  if (parsedPackageFile?.resolutions) {
+    (
+      runtime as BasisTheory.Runtime & {
+        resolutions?: Record<string, string>;
+      }
+    ).resolutions = parsedPackageFile.resolutions;
   }
 
   if (timeout !== undefined) {
@@ -176,8 +249,8 @@ const promptRuntimeOptions = async (
     ],
   });
 
-  const dependencies = await promptStringIfUndefined(flags.dependencies, {
-    message: `${prefix}(Optional) Dependencies file path (JSON format):`,
+  const packageJson = await promptStringIfUndefined(flags['package-json'], {
+    message: `${prefix}(Optional) Runtime package.json file path (JSON format):`,
   });
 
   const permissions = await promptCommaSeparatedIfUndefined(flags.permissions, {
@@ -188,7 +261,7 @@ const promptRuntimeOptions = async (
     timeout,
     warmConcurrency,
     resources,
-    dependencies: dependencies || undefined,
+    packageJson: packageJson || undefined,
     permissions,
   };
 };
@@ -218,6 +291,7 @@ export {
   CONFIGURABLE_RUNTIME_FLAGS,
   isLegacyRuntimeImage,
   validateRuntimeImage,
+  parseRuntimePackageJsonFile,
   buildRuntime,
   promptRuntimeOptions,
   promptRuntimeImage,

--- a/test/unit/commands/proxies/create.test.ts
+++ b/test/unit/commands/proxies/create.test.ts
@@ -163,7 +163,11 @@ describe('proxies create', () => {
 
   describe('with transform runtime flags', () => {
     it('creates proxy with request transform runtime flags', async () => {
-      readFileStub.withArgs('./deps.json').returns('{"lodash": "^4.17.21"}');
+      readFileStub
+        .withArgs('./package.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"resolutions":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
 
       const result = await runCommand([
         'proxies:create',
@@ -181,8 +185,8 @@ describe('proxies create', () => {
         '1',
         '--request-transform-resources',
         'large',
-        '--request-transform-dependencies',
-        './deps.json',
+        '--request-transform-package-json',
+        './package.json',
         '--request-transform-permissions',
         'token:read',
       ]);
@@ -195,8 +199,56 @@ describe('proxies create', () => {
         timeout: 30,
         warmConcurrency: 1,
         resources: 'large',
-        dependencies: { lodash: '^4.17.21' },
+        dependencies: { lodash: '4.17.21' },
+        resolutions: {
+          uuid: '9.0.1',
+          nanoid: '5.0.7',
+        },
         permissions: ['token:read'],
+      });
+    });
+
+    it('uses overrides as resolutions for request transform when resolutions is not present', async () => {
+      readFileStub
+        .withArgs('./runtime-package-overrides.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"overrides":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
+
+      await runCommand([
+        'proxies:create',
+        '--name',
+        'Test Proxy',
+        '--destination-url',
+        'https://example.com/api',
+        '--request-transform-code',
+        './request.js',
+        '--request-transform-image',
+        'node22',
+        '--request-transform-timeout',
+        '10',
+        '--request-transform-warm-concurrency',
+        '0',
+        '--request-transform-resources',
+        'standard',
+        '--request-transform-package-json',
+        './runtime-package-overrides.json',
+        '--request-transform-permissions',
+        'token:read',
+      ]);
+
+      const [createArg] = proxiesCreateStub.firstCall.args;
+
+      expect(
+        createArg.requestTransforms[0].options.runtime.dependencies
+      ).to.deep.equal({
+        lodash: '4.17.21',
+      });
+      expect(
+        createArg.requestTransforms[0].options.runtime.resolutions
+      ).to.deep.equal({
+        uuid: '9.0.1',
+        nanoid: '5.0.7',
       });
     });
 
@@ -219,7 +271,7 @@ describe('proxies create', () => {
           ''
         )
         .onCallResolves(
-          'Response transform: (Optional) Dependencies file path (JSON format):',
+          'Response transform: (Optional) Runtime package.json file path (JSON format):',
           ''
         )
         .onCallResolves(
@@ -281,7 +333,7 @@ describe('proxies create', () => {
           ''
         )
         .onCallResolves(
-          'Request transform: (Optional) Dependencies file path (JSON format):',
+          'Request transform: (Optional) Runtime package.json file path (JSON format):',
           ''
         )
         .onCallResolves(
@@ -336,7 +388,7 @@ describe('proxies create', () => {
           ''
         )
         .onCallResolves(
-          'Request transform: (Optional) Dependencies file path (JSON format):',
+          'Request transform: (Optional) Runtime package.json file path (JSON format):',
           ''
         )
         .onCallResolves(
@@ -473,7 +525,7 @@ describe('proxies create', () => {
           '1'
         )
         .onCallResolves(
-          'Request transform: (Optional) Dependencies file path (JSON format):',
+          'Request transform: (Optional) Runtime package.json file path (JSON format):',
           ''
         )
         .onCallResolves(
@@ -778,13 +830,13 @@ describe('proxies create', () => {
         'node22',
         '--request-transform-resources',
         'standard',
-        '--request-transform-dependencies',
+        '--request-transform-package-json',
         './invalid.json',
       ]);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain(
-        'Failed to parse dependencies file'
+        'Failed to parse package.json file'
       );
     });
   });

--- a/test/unit/commands/proxies/update.test.ts
+++ b/test/unit/commands/proxies/update.test.ts
@@ -165,7 +165,11 @@ describe('proxies update', () => {
 
   describe('with transform runtime flags', () => {
     it('updates proxy with request transform runtime flags', async () => {
-      readFileStub.withArgs('./deps.json').returns('{"lodash": "^4.17.21"}');
+      readFileStub
+        .withArgs('./package.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"resolutions":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
 
       const result = await runCommand([
         'proxies:update',
@@ -180,8 +184,8 @@ describe('proxies update', () => {
         '1',
         '--request-transform-resources',
         'large',
-        '--request-transform-dependencies',
-        './deps.json',
+        '--request-transform-package-json',
+        './package.json',
         '--request-transform-permissions',
         'token:read',
       ]);
@@ -194,8 +198,45 @@ describe('proxies update', () => {
         timeout: 30,
         warmConcurrency: 1,
         resources: 'large',
-        dependencies: { lodash: '^4.17.21' },
+        dependencies: { lodash: '4.17.21' },
+        resolutions: {
+          uuid: '9.0.1',
+          nanoid: '5.0.7',
+        },
         permissions: ['token:read'],
+      });
+    });
+
+    it('uses overrides as resolutions for request transform when resolutions is not present', async () => {
+      readFileStub
+        .withArgs('./runtime-package-overrides.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"overrides":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
+
+      await runCommand([
+        'proxies:update',
+        'proxy-123',
+        '--request-transform-code',
+        './request.js',
+        '--request-transform-image',
+        'node22',
+        '--request-transform-package-json',
+        './runtime-package-overrides.json',
+      ]);
+
+      const [, patchArg] = proxiesPatchStub.firstCall.args;
+
+      expect(
+        patchArg.requestTransforms[0].options.runtime.dependencies
+      ).to.deep.equal({
+        lodash: '4.17.21',
+      });
+      expect(
+        patchArg.requestTransforms[0].options.runtime.resolutions
+      ).to.deep.equal({
+        uuid: '9.0.1',
+        nanoid: '5.0.7',
       });
     });
 
@@ -343,13 +384,13 @@ describe('proxies update', () => {
         './request.js',
         '--request-transform-image',
         'node22',
-        '--request-transform-dependencies',
+        '--request-transform-package-json',
         './invalid.json',
       ]);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain(
-        'Failed to parse dependencies file'
+        'Failed to parse package.json file'
       );
     });
   });

--- a/test/unit/commands/reactors/create.test.ts
+++ b/test/unit/commands/reactors/create.test.ts
@@ -113,7 +113,10 @@ describe('reactors create', () => {
           'Warm concurrency (0-1, press Enter for default: 0):',
           ''
         )
-        .onCallResolves('(Optional) Dependencies file path (JSON format):', '')
+        .onCallResolves(
+          '(Optional) Runtime package.json file path (JSON format):',
+          ''
+        )
         .onCallResolves(
           '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
           ''
@@ -138,7 +141,11 @@ describe('reactors create', () => {
     });
 
     it('creates reactor with all runtime flags', async () => {
-      readFileStub.withArgs('./deps.json').returns('{"lodash": "^4.17.21"}');
+      readFileStub
+        .withArgs('./package.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"resolutions":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
 
       const result = await runCommand([
         'reactors:create',
@@ -154,8 +161,8 @@ describe('reactors create', () => {
         '1',
         '--resources',
         'large',
-        '--dependencies',
-        './deps.json',
+        '--package-json',
+        './package.json',
         '--permissions',
         'token:read',
         '--permissions',
@@ -170,8 +177,50 @@ describe('reactors create', () => {
         timeout: 30,
         warmConcurrency: 1,
         resources: 'large',
-        dependencies: { lodash: '^4.17.21' },
+        dependencies: { lodash: '4.17.21' },
+        resolutions: {
+          uuid: '9.0.1',
+          nanoid: '5.0.7',
+        },
         permissions: ['token:read', 'token:write'],
+      });
+    });
+
+    it('uses overrides as resolutions when resolutions is not present', async () => {
+      readFileStub
+        .withArgs('./runtime-package-overrides.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"overrides":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
+
+      await runCommand([
+        'reactors:create',
+        '--name',
+        'Test Reactor',
+        '--code',
+        './reactor.js',
+        '--image',
+        'node22',
+        '--timeout',
+        '10',
+        '--warm-concurrency',
+        '0',
+        '--resources',
+        'standard',
+        '--package-json',
+        './runtime-package-overrides.json',
+        '--permissions',
+        'token:read',
+      ]);
+
+      const [createArg] = reactorsCreateStub.firstCall.args;
+
+      expect(createArg.runtime.dependencies).to.deep.equal({
+        lodash: '4.17.21',
+      });
+      expect(createArg.runtime.resolutions).to.deep.equal({
+        uuid: '9.0.1',
+        nanoid: '5.0.7',
       });
     });
 
@@ -189,7 +238,10 @@ describe('reactors create', () => {
           'Warm concurrency (0-1, press Enter for default: 0):',
           ''
         )
-        .onCallResolves('(Optional) Dependencies file path (JSON format):', '')
+        .onCallResolves(
+          '(Optional) Runtime package.json file path (JSON format):',
+          ''
+        )
         .onCallResolves(
           '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
           ''
@@ -230,7 +282,10 @@ describe('reactors create', () => {
           'Warm concurrency (0-1, press Enter for default: 0):',
           ''
         )
-        .onCallResolves('(Optional) Dependencies file path (JSON format):', '')
+        .onCallResolves(
+          '(Optional) Runtime package.json file path (JSON format):',
+          ''
+        )
         .onCallResolves(
           '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
           ''
@@ -358,7 +413,10 @@ describe('reactors create', () => {
           'Warm concurrency (0-1, press Enter for default: 0):',
           '1'
         )
-        .onCallResolves('(Optional) Dependencies file path (JSON format):', '')
+        .onCallResolves(
+          '(Optional) Runtime package.json file path (JSON format):',
+          ''
+        )
         .onCallResolves(
           '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
           ''
@@ -467,8 +525,10 @@ describe('reactors create', () => {
       );
     });
 
-    it('errors when --dependencies used with node-bt', async () => {
-      readFileStub.withArgs('./deps.json').returns('{"lodash": "^4.17.21"}');
+    it('errors when --package-json used with node-bt', async () => {
+      readFileStub
+        .withArgs('./package.json')
+        .returns('{"dependencies":{"lodash":"4.17.21"}}');
 
       const result = await runCommand([
         'reactors:create',
@@ -478,13 +538,13 @@ describe('reactors create', () => {
         './reactor.js',
         '--image',
         'node-bt',
-        '--dependencies',
-        './deps.json',
+        '--package-json',
+        './package.json',
       ]);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain(
-        'Configurable runtime flags (--dependencies) require --image node22'
+        'Configurable runtime flags (--package-json) require --image node22'
       );
     });
 
@@ -518,7 +578,10 @@ describe('reactors create', () => {
           ''
         )
         .onCallResolves('Warm concurrency (0-1, press Enter for default):', '')
-        .onCallResolves('(Optional) Dependencies file path (JSON format):', '')
+        .onCallResolves(
+          '(Optional) Runtime package.json file path (JSON format):',
+          ''
+        )
         .onCallResolves(
           '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
           ''
@@ -592,13 +655,13 @@ describe('reactors create', () => {
         'node22',
         '--resources',
         'standard',
-        '--dependencies',
+        '--package-json',
         './invalid.json',
       ]);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain(
-        'Failed to parse dependencies file'
+        'Failed to parse package.json file'
       );
     });
 
@@ -634,7 +697,7 @@ describe('reactors create', () => {
         'node22',
         '--resources',
         'standard',
-        '--dependencies',
+        '--package-json',
         './missing.json',
       ]);
 

--- a/test/unit/commands/reactors/update.test.ts
+++ b/test/unit/commands/reactors/update.test.ts
@@ -129,7 +129,11 @@ describe('reactors update', () => {
     });
 
     it('updates reactor with all runtime flags', async () => {
-      readFileStub.withArgs('./deps.json').returns('{"lodash": "^4.17.21"}');
+      readFileStub
+        .withArgs('./package.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"resolutions":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
 
       const result = await runCommand([
         'reactors:update',
@@ -142,8 +146,8 @@ describe('reactors update', () => {
         '1',
         '--resources',
         'large',
-        '--dependencies',
-        './deps.json',
+        '--package-json',
+        './package.json',
         '--permissions',
         'token:read',
         '--permissions',
@@ -158,8 +162,39 @@ describe('reactors update', () => {
         timeout: 30,
         warmConcurrency: 1,
         resources: 'large',
-        dependencies: { lodash: '^4.17.21' },
+        dependencies: { lodash: '4.17.21' },
+        resolutions: {
+          uuid: '9.0.1',
+          nanoid: '5.0.7',
+        },
         permissions: ['token:read', 'token:write'],
+      });
+    });
+
+    it('uses overrides as resolutions when resolutions is not present', async () => {
+      readFileStub
+        .withArgs('./runtime-package-overrides.json')
+        .returns(
+          '{"dependencies":{"lodash":"4.17.21"},"overrides":{"uuid":"9.0.1","nanoid":"5.0.7"}}'
+        );
+
+      await runCommand([
+        'reactors:update',
+        'reactor-123',
+        '--image',
+        'node22',
+        '--package-json',
+        './runtime-package-overrides.json',
+      ]);
+
+      const [, patchArg] = reactorsPatchStub.firstCall.args;
+
+      expect(patchArg.runtime.dependencies).to.deep.equal({
+        lodash: '4.17.21',
+      });
+      expect(patchArg.runtime.resolutions).to.deep.equal({
+        uuid: '9.0.1',
+        nanoid: '5.0.7',
       });
     });
 
@@ -223,13 +258,13 @@ describe('reactors update', () => {
         'reactor-123',
         '--image',
         'node22',
-        '--dependencies',
+        '--package-json',
         './invalid.json',
       ]);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain(
-        'Failed to parse dependencies file'
+        'Failed to parse package.json file'
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,10 +400,10 @@
     read-pkg-up "^7.0.1"
     semver-regex "^3.1.3"
 
-"@basis-theory/node-sdk@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@basis-theory/node-sdk/-/node-sdk-5.0.0.tgz#b8c689b89f05e3046954ac86900a393bfa44210e"
-  integrity sha512-d+BUTn4+Igb2itSoCDvUI4k3ubtnD21l6SflCvqMz50qHkunE6RYs2OEoBsU1DEE0wghjdIg54rsjYAW3Dum1w==
+"@basis-theory/node-sdk@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@basis-theory/node-sdk/-/node-sdk-5.2.0.tgz#5b0c672f812a611a781d926f0be9a003615865db"
+  integrity sha512-2pRfsSgd3tISeAzt5Td1C2BRnuEc9CD2qppGBq0Ewi+sITMO7epOSoQHRYJcbKguwa4CGDig4dLrk/WP+DVnIQ==
 
 "@colors/colors@1.5.0":
   version "1.5.0"


### PR DESCRIPTION
## What Changed

  - Removed separate runtime package flags (dependencies, resolutions) for reactors and proxies
  - Added unified package-json flags:
      - Reactors: --package-json
      - Proxies:
          - --request-transform-package-json
          - --response-transform-package-json
  - Added support for parsing:
      - required dependencies
      - optional resolutions
      - optional overrides (fallback only if resolutions is missing)
  - Updated help text/examples to document pinned versions
  - Updated tests and examples

  ## Breaking Change

  Old flags were removed and are no longer supported:

  - Reactors: --dependencies, 
  - Proxies: --request-transform-dependencies,  --response-transform-dependencies

  ## Runtime Package File Format

  Accepted top-level keys:

  - dependencies (required)
  - resolutions (optional)
  - overrides (optional fallback)

  Other keys are ignored by the CLI.

  ## Examples

  ### Reactor (node22)

```shell
  ./bin/dev reactors create \
    --name "Pinned Runtime Reactor" \
    --code ./examples/reactor.js \
    --image node22 \
    --package-json ./examples/package.json
```

  ### Proxy (node22 request/response transforms)

```shell
  ./bin/dev proxies create \
    --name "Full Options Proxy" \
    --destination-url https://api.example.com \
    --request-transform-code ./examples/request-transform.js \
    --request-transform-image node22 \
    --request-transform-package-json ./examples/request/package.json \
    --response-transform-code ./examples/response-transform.js \
    --response-transform-image node22 \
    --response-transform-package-json ./examples/response/package.json
```