### PR TITLE
feat!: v4.0.0 — add all public endpoints, config file support, remove interactive prompts, flag beta endpoints

### DIFF
--- a/MANUAL-TESTING.md
+++ b/MANUAL-TESTING.md
@@ -1,0 +1,666 @@
+# Basis Theory CLI - Manual Testing & Usage Guide
+
+## Prerequisites
+
+- Node.js >= 12
+- A Basis Theory account with:
+  - **Management API Key** — for management operations (tenants, applications, reactors, proxies, webhooks, logs, keys)
+  - **Private API Key** — for tokenization operations (tokens, tokenize, detokenize, proxy invoke, reactor invoke, documents, payments, etc.)
+
+```bash
+# Install dependencies and build
+yarn install
+yarn build
+
+# Set environment variables
+export BT_MANAGEMENT_KEY="your_management_key_here"
+export BT_API_KEY="your_private_api_key_here"
+```
+
+---
+
+## Automated Test Script
+
+A comprehensive test script exercises all CLI endpoints against the live API:
+
+```bash
+# Run all tests
+./scripts/test-endpoints.sh
+
+# Skip destructive operations (delete/destroy)
+./scripts/test-endpoints.sh --skip-destructive
+
+# Output all commands as JSON
+./scripts/test-endpoints.sh --json
+
+# See full command output
+./scripts/test-endpoints.sh --verbose
+
+# Test a specific section only
+./scripts/test-endpoints.sh --section tenants
+./scripts/test-endpoints.sh --section tokens
+./scripts/test-endpoints.sh --section webhooks
+```
+
+### Available Sections
+
+| Section | Description |
+|---------|-------------|
+| `tenants` | Tenant get/update, members, invitations, merchants |
+| `logs` | Audit logs, entity types |
+| `webhooks` | Webhook CRUD, events, ping |
+| `keys` | Client encryption keys |
+| `tokens` | Token CRUD, tokenize, detokenize |
+| `token-intents` | Token intent lifecycle |
+| `documents` | Document upload/download |
+| `reactors-invoke` | Reactor invocation (requires `REACTOR_ID`) |
+| `proxies-invoke` | Proxy invocation |
+| `account-updater` | Batch jobs, real-time updates |
+| `network-tokens` | Network token lifecycle (requires `NT_TOKEN_ID`) |
+| `3ds` | 3DS sessions (requires `THREEDS_TOKEN_ID`) |
+| `enrichments` | Bank account verification (requires `BANK_TOKEN_ID`) |
+| `apple-pay` | Apple Pay domains, merchants |
+| `google-pay` | Google Pay merchants |
+| `connections` | Stripe Forward (requires `STRIPE_FORWARD_TEST=true`) |
+| `existing` | Smoke tests for existing commands |
+
+### Extra Environment Variables for Advanced Tests
+
+Some tests require pre-existing resources:
+
+```bash
+export REACTOR_ID="your_reactor_id"        # For reactor invoke tests
+export AU_TOKEN_ID="your_card_token_id"    # For real-time account updater
+export NT_TOKEN_ID="your_card_token_id"    # For network token tests
+export THREEDS_TOKEN_ID="your_card_token"  # For 3DS session tests
+export BANK_TOKEN_ID="your_bank_token"     # For bank account verification
+export STRIPE_FORWARD_TEST=true            # Enable Stripe Forward tests
+```
+
+---
+
+## Command Reference & Usage Examples
+
+### Global Flags
+
+All commands support these flags:
+
+| Flag | Env Var | Description |
+|------|---------|-------------|
+| `--management-key`, `-x` | `BT_MANAGEMENT_KEY` | Management API key (required for management commands) |
+| `--api-key`, `-k` | `BT_API_KEY` | Private API key (for tokenization commands) |
+| `--json` | — | Output results as raw JSON |
+| `--api-base-url` | `BT_API_BASE_URL` | Override API base URL (hidden) |
+
+---
+
+## Management Endpoints
+
+### Tenants
+
+```bash
+# Get current tenant
+bt tenants get
+bt tenants get --json
+
+# Update tenant
+bt tenants update --name "My Tenant"
+bt tenants update --fingerprint-tokens true --deduplicate-tokens true
+
+# Delete tenant (dangerous!)
+bt tenants delete
+bt tenants delete --force
+
+# Get usage report
+bt tenants usage
+bt tenants usage --json
+```
+
+### Tenant Members
+
+```bash
+# List members
+bt tenants members
+bt tenants members --page 1 --size 10
+bt tenants members --user-id "user-uuid-here"
+bt tenants members --json
+
+# Update member role
+bt tenants members update MEMBER_ID --role ADMIN
+bt tenants members update MEMBER_ID --role READ_ONLY
+
+# Remove member
+bt tenants members delete MEMBER_ID
+bt tenants members delete MEMBER_ID --force
+```
+
+### Tenant Invitations
+
+```bash
+# List invitations
+bt tenants invitations
+bt tenants invitations --page 1 --size 10
+
+# Create invitation
+bt tenants invitations create --email "user@example.com"
+bt tenants invitations create --email "user@example.com" --role READ_ONLY
+
+# Resend invitation
+bt tenants invitations resend INVITATION_ID
+
+# Delete invitation
+bt tenants invitations delete INVITATION_ID
+bt tenants invitations delete INVITATION_ID --force
+```
+
+### Tenant Merchants
+
+```bash
+# List merchants (read-only)
+bt tenants merchants
+bt tenants merchants --page 1 --size 10
+```
+
+### Audit Logs
+
+```bash
+# List logs
+bt logs
+bt logs --entity-type token
+bt logs --entity-type application --entity-id "app-uuid"
+bt logs --start-date "2024-01-01T00:00:00Z" --end-date "2024-12-31T23:59:59Z"
+bt logs --json
+
+# List available entity types
+bt logs entity-types
+```
+
+### Webhooks
+
+```bash
+# List webhooks
+bt webhooks
+bt webhooks --json
+
+# Get webhook details
+bt webhooks get WEBHOOK_ID
+
+# Create webhook
+bt webhooks create \
+  --name "Payment Notifications" \
+  --url "https://example.com/webhook" \
+  --events "token.created" \
+  --events "token.deleted" \
+  --notify-email "admin@example.com"
+
+# Update webhook
+bt webhooks update WEBHOOK_ID \
+  --name "Updated Webhook" \
+  --url "https://example.com/webhook-v2" \
+  --events "token.created" \
+  --status enabled
+
+# Delete webhook
+bt webhooks delete WEBHOOK_ID
+bt webhooks delete WEBHOOK_ID --force
+
+# List available event types
+bt webhooks events
+
+# Ping (test delivery)
+bt webhooks ping
+```
+
+### Client Encryption Keys
+
+```bash
+# List keys
+bt keys
+bt keys --json
+
+# Create key (with optional expiration)
+bt keys create
+bt keys create --expires-at "2025-06-01T00:00:00Z"
+
+# Delete key
+bt keys delete KEY_ID
+bt keys delete KEY_ID --force
+```
+
+---
+
+## Tokenization Endpoints
+
+### Tokens
+
+```bash
+# List tokens
+bt tokens
+bt tokens --type card
+bt tokens --container "/pci/high/"
+bt tokens --fingerprint "abc123"
+bt tokens --size 50
+bt tokens --json
+
+# Get token
+bt tokens get TOKEN_ID
+bt tokens get TOKEN_ID --json
+
+# Create token (inline JSON)
+bt tokens create --type token --data '{"value": "sensitive-data"}'
+
+# Create card token
+bt tokens create \
+  --type card \
+  --data '{"number": "4242424242424242", "expiration_month": 12, "expiration_year": 2025, "cvc": "123"}'
+
+# Create token from file
+bt tokens create --type token --file ./token-data.json
+
+# Create token with metadata
+bt tokens create \
+  --type token \
+  --data '{"value": "test"}' \
+  --metadata "user_id=12345" \
+  --metadata "source=cli" \
+  --container "/general/high/"
+
+# Create token with deduplication
+bt tokens create --type card --data '...' --deduplicate --fingerprint-expression '{{ data.number }}'
+
+# Create from token intent
+bt tokens create --token-intent-id INTENT_ID
+
+# Update token
+bt tokens update TOKEN_ID --data '{"value": "updated-data"}'
+bt tokens update TOKEN_ID --metadata "status=verified" --expires-at "2025-12-31T00:00:00Z"
+
+# Delete token
+bt tokens delete TOKEN_ID
+bt tokens delete TOKEN_ID --force
+
+# Search tokens (Lucene syntax)
+bt tokens search --query "type:card"
+bt tokens search --query 'data:4242' --size 50
+bt tokens search --query 'metadata.user_id:12345'
+bt tokens search --query 'container:"/pci/"'
+
+# List available token types
+bt tokens types
+```
+
+### Tokenize (Batch)
+
+```bash
+# Tokenize inline JSON
+bt tokenize --data '{"first_name": "John", "last_name": "Doe"}'
+
+# Tokenize from file
+bt tokenize --file ./data-to-tokenize.json
+
+# Tokenize with typed tokens
+bt tokenize --data '{
+  "card": {
+    "type": "card",
+    "data": {
+      "number": "4242424242424242",
+      "expiration_month": 12,
+      "expiration_year": 2025
+    }
+  },
+  "ssn": {
+    "type": "social_security_number",
+    "data": "123-45-6789"
+  }
+}'
+```
+
+### Detokenize
+
+```bash
+# Detokenize with token expressions
+bt detokenize --data '{"card_number": "{{ TOKEN_ID | json: \"$.number\" }}"}'
+
+# Detokenize from file
+bt detokenize --file ./detokenize-request.json
+
+# Full token detokenization
+bt detokenize --data '{"tokens": ["{{ token: TOKEN_ID }}"]}'
+```
+
+### Token Intents
+
+```bash
+# Create token intent (card)
+bt token-intents create \
+  --type card \
+  --data '{"number": "4242424242424242", "expiration_month": 12, "expiration_year": 2026, "cvc": "123"}'
+
+# Get token intent
+bt token-intents get INTENT_ID
+
+# Delete token intent
+bt token-intents delete INTENT_ID
+bt token-intents delete INTENT_ID --force
+```
+
+### Documents
+
+```bash
+# Upload document
+bt documents upload --file ./document.pdf
+bt documents upload --file ./document.pdf --metadata "type=invoice" --metadata "customer_id=123"
+
+# Get document metadata
+bt documents get DOCUMENT_ID
+
+# Download document
+bt documents download DOCUMENT_ID
+bt documents download DOCUMENT_ID --output ./downloaded-file.pdf
+
+# Delete document
+bt documents delete DOCUMENT_ID
+bt documents delete DOCUMENT_ID --force
+```
+
+### Invoke Proxies
+
+```bash
+# Invoke ephemeral proxy (forward request to destination)
+bt proxies invoke \
+  --method POST \
+  --proxy-url "https://api.example.com/charges" \
+  --data '{"amount": 1000, "card": "{{ TOKEN_ID }}"}'
+
+# Invoke ephemeral proxy (GET)
+bt proxies invoke \
+  --method GET \
+  --proxy-url "https://api.example.com/status"
+
+# Invoke pre-configured proxy
+bt proxies invoke \
+  --proxy-key "PROXY_KEY" \
+  --data '{"amount": 1000}' \
+  --path "charges"
+
+# With custom path appended
+bt proxies invoke \
+  --method PUT \
+  --proxy-url "https://api.example.com" \
+  --path "customers/123" \
+  --data '{"name": "Updated Name"}'
+```
+
+### Invoke Reactors
+
+```bash
+# Invoke reactor (synchronous)
+bt reactors invoke REACTOR_ID --data '{"key": "value"}'
+bt reactors invoke REACTOR_ID --file ./reactor-input.json
+
+# Invoke reactor (asynchronous)
+bt reactors invoke-async REACTOR_ID --data '{"key": "value"}'
+# Returns: asyncReactorRequestId
+
+# Get async result
+bt reactors get-result REACTOR_ID REQUEST_ID
+```
+
+---
+
+## Payment Endpoints
+
+### Apple Pay
+
+```bash
+# Tokenize Apple Pay payment
+bt apple-pay create --file ./apple-pay-token.json
+bt apple-pay create \
+  --data '{"paymentData": {...}, "paymentMethod": {...}}' \
+  --expires-at "2025-12-31T00:00:00Z" \
+  --merchant-registration-id MERCHANT_ID
+
+# Get Apple Pay token
+bt apple-pay get APPLE_PAY_TOKEN_ID
+
+# Delete Apple Pay token
+bt apple-pay delete APPLE_PAY_TOKEN_ID --force
+
+# Create merchant session
+bt apple-pay session \
+  --display-name "My Store" \
+  --domain "mystore.example.com"
+
+# Domain management
+bt apple-pay domains                                      # List domains
+bt apple-pay domains register --domain "shop.example.com" # Register
+bt apple-pay domains deregister --domain "shop.example.com" # Deregister
+
+# Merchant registration
+bt apple-pay merchants create --merchant-identifier "merchant.com.example"
+bt apple-pay merchants get MERCHANT_ID
+bt apple-pay merchants delete MERCHANT_ID --force
+
+# Merchant certificates
+bt apple-pay merchants certificates create MERCHANT_ID \
+  --merchant-cert ./merchant.p12 \
+  --merchant-cert-password "password" \
+  --processor-cert ./processor.p12 \
+  --processor-cert-password "password" \
+  --domain "shop.example.com"
+bt apple-pay merchants certificates get MERCHANT_ID CERT_ID
+bt apple-pay merchants certificates delete MERCHANT_ID CERT_ID --force
+```
+
+### Google Pay
+
+```bash
+# Tokenize Google Pay payment
+bt google-pay create --file ./google-pay-token.json
+bt google-pay create \
+  --data '{"protocolVersion": "...", "signature": "...", "signedMessage": "..."}' \
+  --merchant-registration-id MERCHANT_ID
+
+# Get / Delete Google Pay token
+bt google-pay get GOOGLE_PAY_TOKEN_ID
+bt google-pay delete GOOGLE_PAY_TOKEN_ID --force
+
+# Merchant registration
+bt google-pay merchants create --merchant-identifier "merchant-id"
+bt google-pay merchants get MERCHANT_ID
+bt google-pay merchants delete MERCHANT_ID --force
+
+# Merchant certificates
+bt google-pay merchants certificates create MERCHANT_ID \
+  --merchant-cert ./merchant.p12 \
+  --merchant-cert-password "password"
+bt google-pay merchants certificates get MERCHANT_ID CERT_ID
+bt google-pay merchants certificates delete MERCHANT_ID CERT_ID --force
+```
+
+---
+
+## Credential Management Endpoints
+
+### Account Updater
+
+```bash
+# List batch jobs
+bt account-updater jobs
+bt account-updater jobs --size 50
+
+# Create batch job (returns upload URL)
+bt account-updater jobs create
+
+# Get job status
+bt account-updater jobs get JOB_ID
+
+# Real-time account update
+bt account-updater real-time \
+  --token-id CARD_TOKEN_ID \
+  --expiration-month 12 \
+  --expiration-year 2026 \
+  --deduplicate-token
+```
+
+### Network Tokens
+
+```bash
+# Create network token (from existing card token)
+bt network-tokens create --token-id CARD_TOKEN_ID
+
+# Create network token (from token intent)
+bt network-tokens create --token-intent-id INTENT_ID
+
+# Create network token (from raw card data)
+bt network-tokens create --data '{"number": "4242424242424242", "expirationMonth": "12", "expirationYear": "2025"}'
+
+# Get network token
+bt network-tokens get NETWORK_TOKEN_ID
+
+# Generate cryptogram
+bt network-tokens cryptogram NETWORK_TOKEN_ID
+
+# Suspend / Resume
+bt network-tokens suspend NETWORK_TOKEN_ID
+bt network-tokens resume NETWORK_TOKEN_ID
+
+# Delete
+bt network-tokens delete NETWORK_TOKEN_ID --force
+```
+
+### 3DS Sessions
+
+```bash
+# Create 3DS session
+bt 3ds sessions create --token-id CARD_TOKEN_ID
+bt 3ds sessions create --token-intent-id INTENT_ID --type customer --device browser
+
+# Create with full request JSON
+bt 3ds sessions create --file ./3ds-session-request.json
+
+# Get session
+bt 3ds sessions get SESSION_ID
+
+# Authenticate session
+bt 3ds sessions authenticate SESSION_ID \
+  --data '{
+    "authentication_category": "payment",
+    "authentication_type": "payment-transaction",
+    "purchase_info": {"amount": "1000", "currency": "USD"},
+    "cardholder_info": {"name": "John Doe", "email": "john@example.com"}
+  }'
+
+# Get challenge result
+bt 3ds sessions challenge-result SESSION_ID
+```
+
+### Enrichments
+
+```bash
+# Verify bank account
+bt enrichments bank-account-verify --token-id BANK_TOKEN_ID
+bt enrichments bank-account-verify --token-id BANK_TOKEN_ID --country-code US --routing-number "021000021"
+```
+
+### Connections (Stripe Forward)
+
+```bash
+# Tokenize card via Stripe Forward
+bt connections stripe-forward tokenize \
+  --data '{"number": "4242424242424242", "exp_month": "12", "exp_year": "2026", "cvc": "123", "name": "John Doe"}'
+
+bt connections stripe-forward tokenize --file ./card-data.json
+```
+
+---
+
+## Scripting & Automation
+
+### JSON Output for Scripting
+
+All commands support `--json` for machine-readable output:
+
+```bash
+# Create token and capture ID
+TOKEN_ID=$(bt tokens create --type token --data '{"value": "test"}' --json | jq -r '.id')
+echo "Created token: $TOKEN_ID"
+
+# List and process tokens
+bt tokens --json | jq '.[] | {id, type}'
+
+# Create webhook and get ID
+WEBHOOK_ID=$(bt webhooks create --name "My Hook" --url "https://example.com" --events "token.created" --json | jq -r '.id')
+```
+
+### Using with Environment Variables
+
+```bash
+# Use different keys for different operations
+BT_MANAGEMENT_KEY=mgmt_key bt tenants get
+BT_API_KEY=private_key bt tokens create --type token --data '{"x":"y"}'
+
+# Override API base URL (for testing)
+BT_API_BASE_URL=https://api-staging.basistheory.com bt tenants get
+```
+
+### Piping and Composition
+
+```bash
+# Create a token and immediately get its details
+TOKEN_ID=$(bt tokens create --type token --data '{"secret": "value"}' --json | jq -r '.id')
+bt tokens get "$TOKEN_ID" --json | jq '.data'
+
+# Batch operations with xargs
+echo -e "tok-1\ntok-2\ntok-3" | xargs -I {} bt tokens delete {} --force
+
+# Export webhook events to file
+bt webhooks events --json > event-types.json
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Missing required flag: --management-key` | No API key provided | Set `BT_MANAGEMENT_KEY` env var |
+| `Unauthorized [401]` | Invalid or expired API key | Check key permissions in the portal |
+| `Forbidden [403]` | Key lacks required permissions | Add the needed permission to your application |
+| `Not Found [404]` | Resource doesn't exist | Verify the ID is correct |
+| `Either --api-key or --management-key must be provided` | Tokenization command without key | Set `BT_API_KEY` or `BT_MANAGEMENT_KEY` |
+
+### Debug Mode
+
+```bash
+# Enable debug logging
+DEBUG=* bt tenants get
+
+# Debug specific modules
+DEBUG=applications:management bt applications
+```
+
+---
+
+## Unit Tests
+
+Run the full unit test suite:
+
+```bash
+yarn test
+```
+
+Run specific test files:
+
+```bash
+# All tenant tests
+yarn test test/unit/commands/tenants/**/*.test.ts
+
+# Specific command test
+yarn test test/unit/commands/webhooks/create.test.ts
+
+# Pattern matching
+yarn test --grep "webhooks create"
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,23 @@ Basis Theory CLI
 
 Basis Theory CLI tool
 
-Make sure to either have a `BT_MANAGEMENT_KEY` env var exported or pass a `management-key` flag to the commands.
+## Authentication
+
+API keys can be provided in three ways (in order of precedence):
+
+1. **Flags**: `--api-key` or `--management-key`
+2. **Environment variables**: `BT_API_KEY`, `BT_MANAGEMENT_KEY`
+3. **Config file**: `~/.basistheory/cli.json`
+
+The config file is automatically created on first run. Example:
+
+```json
+{
+  "apiKey": "key_...",
+  "managementApiKey": "key_...",
+  "apiBaseUrl": "https://api.basistheory.com"
+}
+```
 
 <!-- toc -->
 * [Usage](#usage)
@@ -19,7 +35,7 @@ $ npm install -g @basis-theory-labs/cli
 $ bt COMMAND
 running command...
 $ bt (--version)
-@basis-theory-labs/cli/3.0.0 linux-x64 node-v18.20.8
+@basis-theory-labs/cli/4.0.0 darwin-arm64 node-v25.9.0
 $ bt --help [COMMAND]
 USAGE
   $ bt COMMAND
@@ -28,20 +44,594 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
+* [`bt 3ds sessions authenticate ID`](#bt-3ds-sessions-authenticate-id)
+* [`bt 3ds sessions challenge-result ID`](#bt-3ds-sessions-challenge-result-id)
+* [`bt 3ds sessions create`](#bt-3ds-sessions-create)
+* [`bt 3ds sessions get ID`](#bt-3ds-sessions-get-id)
+* [`bt account-updater jobs`](#bt-account-updater-jobs)
+* [`bt account-updater jobs create`](#bt-account-updater-jobs-create)
+* [`bt account-updater jobs get ID`](#bt-account-updater-jobs-get-id)
+* [`bt account-updater real-time`](#bt-account-updater-real-time)
+* [`bt apple-pay create`](#bt-apple-pay-create)
+* [`bt apple-pay delete ID`](#bt-apple-pay-delete-id)
+* [`bt apple-pay domains`](#bt-apple-pay-domains)
+* [`bt apple-pay domains deregister`](#bt-apple-pay-domains-deregister)
+* [`bt apple-pay domains register`](#bt-apple-pay-domains-register)
+* [`bt apple-pay get ID`](#bt-apple-pay-get-id)
+* [`bt apple-pay merchants certificates create MERCHANT-ID`](#bt-apple-pay-merchants-certificates-create-merchant-id)
+* [`bt apple-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID`](#bt-apple-pay-merchants-certificates-delete-merchant-id-certificate-id)
+* [`bt apple-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID`](#bt-apple-pay-merchants-certificates-get-merchant-id-certificate-id)
+* [`bt apple-pay merchants create`](#bt-apple-pay-merchants-create)
+* [`bt apple-pay merchants delete ID`](#bt-apple-pay-merchants-delete-id)
+* [`bt apple-pay merchants get ID`](#bt-apple-pay-merchants-get-id)
+* [`bt apple-pay session`](#bt-apple-pay-session)
 * [`bt applications`](#bt-applications)
 * [`bt applications create`](#bt-applications-create)
 * [`bt applications delete ID`](#bt-applications-delete-id)
 * [`bt applications update ID`](#bt-applications-update-id)
+* [`bt connections stripe-forward tokenize`](#bt-connections-stripe-forward-tokenize)
+* [`bt detokenize`](#bt-detokenize)
+* [`bt documents delete ID`](#bt-documents-delete-id)
+* [`bt documents download ID`](#bt-documents-download-id)
+* [`bt documents get ID`](#bt-documents-get-id)
+* [`bt documents upload`](#bt-documents-upload)
+* [`bt enrichments bank-account-verify`](#bt-enrichments-bank-account-verify)
+* [`bt google-pay create`](#bt-google-pay-create)
+* [`bt google-pay delete ID`](#bt-google-pay-delete-id)
+* [`bt google-pay get ID`](#bt-google-pay-get-id)
+* [`bt google-pay merchants certificates create MERCHANT-ID`](#bt-google-pay-merchants-certificates-create-merchant-id)
+* [`bt google-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID`](#bt-google-pay-merchants-certificates-delete-merchant-id-certificate-id)
+* [`bt google-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID`](#bt-google-pay-merchants-certificates-get-merchant-id-certificate-id)
+* [`bt google-pay merchants create`](#bt-google-pay-merchants-create)
+* [`bt google-pay merchants delete ID`](#bt-google-pay-merchants-delete-id)
+* [`bt google-pay merchants get ID`](#bt-google-pay-merchants-get-id)
+* [`bt keys`](#bt-keys)
+* [`bt keys create`](#bt-keys-create)
+* [`bt keys delete ID`](#bt-keys-delete-id)
+* [`bt logs`](#bt-logs)
+* [`bt logs entity-types`](#bt-logs-entity-types)
+* [`bt network-tokens create`](#bt-network-tokens-create)
+* [`bt network-tokens cryptogram ID`](#bt-network-tokens-cryptogram-id)
+* [`bt network-tokens delete ID`](#bt-network-tokens-delete-id)
+* [`bt network-tokens get ID`](#bt-network-tokens-get-id)
+* [`bt network-tokens resume ID`](#bt-network-tokens-resume-id)
+* [`bt network-tokens suspend ID`](#bt-network-tokens-suspend-id)
 * [`bt proxies`](#bt-proxies)
 * [`bt proxies create`](#bt-proxies-create)
 * [`bt proxies delete ID`](#bt-proxies-delete-id)
-* [`bt proxies logs [ID]`](#bt-proxies-logs-id)
+* [`bt proxies invoke`](#bt-proxies-invoke)
+* [`bt proxies logs ID`](#bt-proxies-logs-id)
 * [`bt proxies update ID`](#bt-proxies-update-id)
 * [`bt reactors`](#bt-reactors)
 * [`bt reactors create`](#bt-reactors-create)
 * [`bt reactors delete ID`](#bt-reactors-delete-id)
-* [`bt reactors logs [ID]`](#bt-reactors-logs-id)
+* [`bt reactors get-result ID REQUEST-ID`](#bt-reactors-get-result-id-request-id)
+* [`bt reactors invoke ID`](#bt-reactors-invoke-id)
+* [`bt reactors invoke-async ID`](#bt-reactors-invoke-async-id)
+* [`bt reactors logs ID`](#bt-reactors-logs-id)
 * [`bt reactors update ID`](#bt-reactors-update-id)
+* [`bt tenants delete`](#bt-tenants-delete)
+* [`bt tenants get`](#bt-tenants-get)
+* [`bt tenants invitations`](#bt-tenants-invitations)
+* [`bt tenants invitations create`](#bt-tenants-invitations-create)
+* [`bt tenants invitations delete ID`](#bt-tenants-invitations-delete-id)
+* [`bt tenants invitations resend ID`](#bt-tenants-invitations-resend-id)
+* [`bt tenants members`](#bt-tenants-members)
+* [`bt tenants members delete ID`](#bt-tenants-members-delete-id)
+* [`bt tenants members update ID`](#bt-tenants-members-update-id)
+* [`bt tenants merchants`](#bt-tenants-merchants)
+* [`bt tenants update`](#bt-tenants-update)
+* [`bt tenants usage`](#bt-tenants-usage)
+* [`bt token-intents create`](#bt-token-intents-create)
+* [`bt token-intents delete ID`](#bt-token-intents-delete-id)
+* [`bt token-intents get ID`](#bt-token-intents-get-id)
+* [`bt tokenize`](#bt-tokenize)
+* [`bt tokens`](#bt-tokens)
+* [`bt tokens create`](#bt-tokens-create)
+* [`bt tokens delete ID`](#bt-tokens-delete-id)
+* [`bt tokens get ID`](#bt-tokens-get-id)
+* [`bt tokens search`](#bt-tokens-search)
+* [`bt tokens types`](#bt-tokens-types)
+* [`bt tokens update ID`](#bt-tokens-update-id)
+* [`bt webhooks`](#bt-webhooks)
+* [`bt webhooks create`](#bt-webhooks-create)
+* [`bt webhooks delete ID`](#bt-webhooks-delete-id)
+* [`bt webhooks events`](#bt-webhooks-events)
+* [`bt webhooks get ID`](#bt-webhooks-get-id)
+* [`bt webhooks ping`](#bt-webhooks-ping)
+* [`bt webhooks update ID`](#bt-webhooks-update-id)
+
+## `bt 3ds sessions authenticate ID`
+
+Authenticate a 3DS session
+
+```
+USAGE
+  $ bt 3ds sessions authenticate ID [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+ARGUMENTS
+  ID  3DS session id to authenticate
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                authentication request as JSON string
+  --file=<value>                path to JSON file containing authentication request
+  --json                        output results as JSON
+
+DESCRIPTION
+  Authenticate a 3DS session
+
+EXAMPLES
+  $ bt 3ds sessions authenticate sess-123 --data '{"authenticationCategory":"payment"}'
+```
+
+## `bt 3ds sessions challenge-result ID`
+
+Get a 3DS session challenge result
+
+```
+USAGE
+  $ bt 3ds sessions challenge-result ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  3DS session id
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a 3DS session challenge result
+
+EXAMPLES
+  $ bt 3ds sessions challenge-result sess-123
+```
+
+## `bt 3ds sessions create`
+
+Create a 3DS session
+
+```
+USAGE
+  $ bt 3ds sessions create [-x <value>] [-k <value>] [--json] [--token-id <value>] [--token-intent-id <value>] [--type
+    <value>] [--device <value>] [--data <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                session request as JSON string
+  --device=<value>              device type
+  --file=<value>                path to JSON file containing session request
+  --json                        output results as JSON
+  --token-id=<value>            token ID to use
+  --token-intent-id=<value>     token intent ID to use
+  --type=<value>                session type
+
+DESCRIPTION
+  Create a 3DS session
+
+EXAMPLES
+  $ bt 3ds sessions create
+```
+
+## `bt 3ds sessions get ID`
+
+Get a 3DS session by ID
+
+```
+USAGE
+  $ bt 3ds sessions get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  3DS session id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a 3DS session by ID
+
+EXAMPLES
+  $ bt 3ds sessions get sess-123
+```
+
+## `bt account-updater jobs`
+
+List account updater jobs
+
+```
+USAGE
+  $ bt account-updater jobs [-x <value>] [-k <value>] [--json] [--size <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+  --size=<value>                [default: 20] number of jobs to return
+
+DESCRIPTION
+  List account updater jobs
+
+EXAMPLES
+  $ bt account-updater jobs
+```
+
+## `bt account-updater jobs create`
+
+Create an account updater job
+
+```
+USAGE
+  $ bt account-updater jobs create [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Create an account updater job
+
+EXAMPLES
+  $ bt account-updater jobs create
+```
+
+## `bt account-updater jobs get ID`
+
+Get an account updater job by ID
+
+```
+USAGE
+  $ bt account-updater jobs get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Job id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get an account updater job by ID
+
+EXAMPLES
+  $ bt account-updater jobs get job-123
+```
+
+## `bt account-updater real-time`
+
+Invoke account updater real-time
+
+```
+USAGE
+  $ bt account-updater real-time --token-id <value> [-x <value>] [-k <value>] [--json] [--expiration-month <value>]
+    [--expiration-year <value>] [--deduplicate-token]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --deduplicate-token           deduplicate token
+  --expiration-month=<value>    expiration month
+  --expiration-year=<value>     expiration year
+  --json                        output results as JSON
+  --token-id=<value>            (required) token ID to update
+
+DESCRIPTION
+  Invoke account updater real-time
+
+EXAMPLES
+  $ bt account-updater real-time --token-id tok-123
+```
+
+## `bt apple-pay create`
+
+Create an Apple Pay token
+
+```
+USAGE
+  $ bt apple-pay create [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>] [--expires-at <value>]
+    [--merchant-registration-id <value>]
+
+FLAGS
+  -k, --api-key=<value>               private API key used for API authentication
+  -x, --management-key=<value>        management key used for API authentication
+  --data=<value>                      Apple payment data as JSON string
+  --expires-at=<value>                expiration date for the token
+  --file=<value>                      path to JSON file containing Apple payment data
+  --json                              output results as JSON
+  --merchant-registration-id=<value>  merchant registration ID
+
+DESCRIPTION
+  Create an Apple Pay token
+
+EXAMPLES
+  $ bt apple-pay create
+```
+
+## `bt apple-pay delete ID`
+
+Delete an Apple Pay token
+
+```
+USAGE
+  $ bt apple-pay delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Apple Pay token id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete an Apple Pay token
+
+EXAMPLES
+  $ bt apple-pay delete ap-123
+```
+
+## `bt apple-pay domains`
+
+List registered Apple Pay domains
+
+```
+USAGE
+  $ bt apple-pay domains [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  List registered Apple Pay domains
+
+EXAMPLES
+  $ bt apple-pay domains
+```
+
+## `bt apple-pay domains deregister`
+
+Deregister an Apple Pay domain
+
+```
+USAGE
+  $ bt apple-pay domains deregister --domain <value> [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --domain=<value>              (required) domain to deregister
+  --json                        output results as JSON
+
+DESCRIPTION
+  Deregister an Apple Pay domain
+
+EXAMPLES
+  $ bt apple-pay domains deregister
+```
+
+## `bt apple-pay domains register`
+
+Register an Apple Pay domain
+
+```
+USAGE
+  $ bt apple-pay domains register --domain <value> [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --domain=<value>              (required) domain to register
+  --json                        output results as JSON
+
+DESCRIPTION
+  Register an Apple Pay domain
+
+EXAMPLES
+  $ bt apple-pay domains register
+```
+
+## `bt apple-pay get ID`
+
+Get an Apple Pay token by ID
+
+```
+USAGE
+  $ bt apple-pay get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Apple Pay token id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get an Apple Pay token by ID
+
+EXAMPLES
+  $ bt apple-pay get ap-123
+```
+
+## `bt apple-pay merchants certificates create MERCHANT-ID`
+
+Create Apple Pay merchant certificates
+
+```
+USAGE
+  $ bt apple-pay merchants certificates create MERCHANT-ID --merchant-cert <value> --merchant-cert-password <value> --processor-cert <value>
+    --processor-cert-password <value> --domain <value> [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  MERCHANT-ID  Apple Pay merchant id
+
+FLAGS
+  -k, --api-key=<value>              private API key used for API authentication
+  -x, --management-key=<value>       management key used for API authentication
+  --domain=<value>                   (required) domain for the certificate
+  --json                             output results as JSON
+  --merchant-cert=<value>            (required) path to merchant P12 certificate file
+  --merchant-cert-password=<value>   (required) password for the merchant certificate
+  --processor-cert=<value>           (required) path to processor certificate file
+  --processor-cert-password=<value>  (required) password for the processor certificate
+
+DESCRIPTION
+  Create Apple Pay merchant certificates
+
+EXAMPLES
+  $ bt apple-pay merchants certificates create merch-123
+```
+
+## `bt apple-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID`
+
+Delete Apple Pay merchant certificates
+
+```
+USAGE
+  $ bt apple-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  MERCHANT-ID     Apple Pay merchant id
+  CERTIFICATE-ID  certificate id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete Apple Pay merchant certificates
+
+EXAMPLES
+  $ bt apple-pay merchants certificates delete merch-123 cert-456
+```
+
+## `bt apple-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID`
+
+Get Apple Pay merchant certificates
+
+```
+USAGE
+  $ bt apple-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  MERCHANT-ID     Apple Pay merchant id
+  CERTIFICATE-ID  certificate id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get Apple Pay merchant certificates
+
+EXAMPLES
+  $ bt apple-pay merchants certificates get merch-123 cert-456
+```
+
+## `bt apple-pay merchants create`
+
+Create an Apple Pay merchant
+
+```
+USAGE
+  $ bt apple-pay merchants create --merchant-identifier <value> [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>          private API key used for API authentication
+  -x, --management-key=<value>   management key used for API authentication
+  --json                         output results as JSON
+  --merchant-identifier=<value>  (required) merchant identifier
+
+DESCRIPTION
+  Create an Apple Pay merchant
+
+EXAMPLES
+  $ bt apple-pay merchants create
+```
+
+## `bt apple-pay merchants delete ID`
+
+Delete an Apple Pay merchant
+
+```
+USAGE
+  $ bt apple-pay merchants delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Apple Pay merchant id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete an Apple Pay merchant
+
+EXAMPLES
+  $ bt apple-pay merchants delete merch-123
+```
+
+## `bt apple-pay merchants get ID`
+
+Get an Apple Pay merchant by ID
+
+```
+USAGE
+  $ bt apple-pay merchants get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Apple Pay merchant id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get an Apple Pay merchant by ID
+
+EXAMPLES
+  $ bt apple-pay merchants get merch-123
+```
+
+## `bt apple-pay session`
+
+Create an Apple Pay session
+
+```
+USAGE
+  $ bt apple-pay session --display-name <value> --domain <value> [-x <value>] [-k <value>] [--json] [--validation-url
+    <value>] [--merchant-registration-id <value>]
+
+FLAGS
+  -k, --api-key=<value>               private API key used for API authentication
+  -x, --management-key=<value>        management key used for API authentication
+  --display-name=<value>              (required) display name for the session
+  --domain=<value>                    (required) domain for the session
+  --json                              output results as JSON
+  --merchant-registration-id=<value>  merchant registration ID
+  --validation-url=<value>            validation URL for the session
+
+DESCRIPTION
+  Create an Apple Pay session
+
+EXAMPLES
+  $ bt apple-pay session
+```
 
 ## `bt applications`
 
@@ -49,11 +639,13 @@ List Applications. Requires `application:read` Management Application permission
 
 ```
 USAGE
-  $ bt applications -x <value> [-p <value>]
+  $ bt applications [-x <value>] [--json] [-p <value>] [-s <value>]
 
 FLAGS
   -p, --page=<value>            [default: 1] Applications list page to fetch
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   List Applications. Requires `application:read` Management Application permission
@@ -62,7 +654,7 @@ EXAMPLES
   $ bt applications
 ```
 
-_See code: [dist/commands/applications/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v3.0.0/dist/commands/applications/index.ts)_
+_See code: [dist/commands/applications/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/applications/index.ts)_
 
 ## `bt applications create`
 
@@ -70,15 +662,16 @@ Creates a new Application. Requires `application:create` Management Application 
 
 ```
 USAGE
-  $ bt applications create -x <value> [-n <value>] [-p <value>] [-t private|public|management] [-z <value>]
+  $ bt applications create [-x <value>] [--json] [-n <value>] [-p <value>] [-t private|public|management] [-z <value>]
 
 FLAGS
   -n, --name=<value>            name of the Application
   -p, --permission=<value>...   permission(s) to use in the Application
   -t, --type=<option>           type of the Application
                                 <options: private|public|management>
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   -z, --template=<value>        template ID to create the application with
+  --json                        output results as JSON
 
 DESCRIPTION
   Creates a new Application. Requires `application:create` Management Application permission
@@ -93,14 +686,15 @@ Deletes a Application. Requires `application:delete` Management Application perm
 
 ```
 USAGE
-  $ bt applications delete ID -x <value> [-y]
+  $ bt applications delete ID [-x <value>] [--json] [-y]
 
 ARGUMENTS
   ID  Application id to delete
 
 FLAGS
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   -y, --yes                     auto confirm the operation
+  --json                        output results as JSON
 
 DESCRIPTION
   Deletes a Application. Requires `application:delete` Management Application permissions
@@ -115,7 +709,7 @@ Updates a new Application. Requires `application:update` Management Application 
 
 ```
 USAGE
-  $ bt applications update ID -x <value> [-n <value>] [-p <value>]
+  $ bt applications update ID [-x <value>] [--json] [-n <value>] [-p <value>]
 
 ARGUMENTS
   ID  Application id to update
@@ -123,7 +717,8 @@ ARGUMENTS
 FLAGS
   -n, --name=<value>            name of the Application
   -p, --permission=<value>...   permission(s) to use in the Application
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   Updates a new Application. Requires `application:update` Management Application permission
@@ -132,17 +727,653 @@ EXAMPLES
   $ bt applications update
 ```
 
+## `bt connections stripe-forward tokenize`
+
+Forward tokenize via Stripe connection
+
+```
+USAGE
+  $ bt connections stripe-forward tokenize [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                card data as JSON string
+  --file=<value>                path to JSON file containing card data
+  --json                        output results as JSON
+
+DESCRIPTION
+  Forward tokenize via Stripe connection
+
+EXAMPLES
+  $ bt connections stripe-forward tokenize --data '{"number":"4242424242424242"}'
+```
+
+## `bt detokenize`
+
+Detokenize data
+
+```
+USAGE
+  $ bt detokenize [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                JSON data to detokenize
+  --file=<value>                path to JSON file containing data to detokenize
+  --json                        output results as JSON
+
+DESCRIPTION
+  Detokenize data
+
+EXAMPLES
+  $ bt detokenize --data '{"token_id":"tok-123"}'
+```
+
+_See code: [dist/commands/detokenize.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/detokenize.ts)_
+
+## `bt documents delete ID`
+
+Deletes a document
+
+```
+USAGE
+  $ bt documents delete ID [-x <value>] [-k <value>] [--json] [--force]
+
+ARGUMENTS
+  ID  Document ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --force                       skip confirmation prompt
+  --json                        output results as JSON
+
+DESCRIPTION
+  Deletes a document
+
+EXAMPLES
+  $ bt documents delete doc-123
+
+  $ bt documents delete doc-123 --force
+```
+
+## `bt documents download ID`
+
+Downloads a document by ID
+
+```
+USAGE
+  $ bt documents download ID [-x <value>] [-k <value>] [--json] [--output <value>]
+
+ARGUMENTS
+  ID  Document ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+  --output=<value>              output file path
+
+DESCRIPTION
+  Downloads a document by ID
+
+EXAMPLES
+  $ bt documents download doc-123
+
+  $ bt documents download doc-123 --output ./downloaded.pdf
+```
+
+## `bt documents get ID`
+
+Gets a document by ID
+
+```
+USAGE
+  $ bt documents get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Document ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Gets a document by ID
+
+EXAMPLES
+  $ bt documents get doc-123
+```
+
+## `bt documents upload`
+
+Uploads a document
+
+```
+USAGE
+  $ bt documents upload --file <value> [-x <value>] [-k <value>] [--json] [--metadata <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --file=<value>                (required) path to the document file
+  --json                        output results as JSON
+  --metadata=<value>...         metadata key=value pairs
+
+DESCRIPTION
+  Uploads a document
+
+EXAMPLES
+  $ bt documents upload --file ./document.pdf
+
+  $ bt documents upload --file ./document.pdf --metadata key1=value1 --metadata key2=value2
+```
+
+## `bt enrichments bank-account-verify`
+
+Verify a bank account
+
+```
+USAGE
+  $ bt enrichments bank-account-verify --token-id <value> [-x <value>] [-k <value>] [--json] [--country-code <value>]
+    [--routing-number <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --country-code=<value>        [default: US] country code
+  --json                        output results as JSON
+  --routing-number=<value>      routing number
+  --token-id=<value>            (required) token ID for the bank account
+
+DESCRIPTION
+  Verify a bank account
+
+EXAMPLES
+  $ bt enrichments bank-account-verify --token-id tok-123
+```
+
+## `bt google-pay create`
+
+Create a Google Pay token
+
+```
+USAGE
+  $ bt google-pay create [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>] [--expires-at <value>]
+    [--merchant-registration-id <value>]
+
+FLAGS
+  -k, --api-key=<value>               private API key used for API authentication
+  -x, --management-key=<value>        management key used for API authentication
+  --data=<value>                      Google payment data as JSON string
+  --expires-at=<value>                expiration date for the token
+  --file=<value>                      path to JSON file containing Google payment data
+  --json                              output results as JSON
+  --merchant-registration-id=<value>  merchant registration ID
+
+DESCRIPTION
+  Create a Google Pay token
+
+EXAMPLES
+  $ bt google-pay create
+```
+
+## `bt google-pay delete ID`
+
+Delete a Google Pay token
+
+```
+USAGE
+  $ bt google-pay delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Google Pay token id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a Google Pay token
+
+EXAMPLES
+  $ bt google-pay delete gp-123
+```
+
+## `bt google-pay get ID`
+
+Get a Google Pay token by ID
+
+```
+USAGE
+  $ bt google-pay get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Google Pay token id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a Google Pay token by ID
+
+EXAMPLES
+  $ bt google-pay get gp-123
+```
+
+## `bt google-pay merchants certificates create MERCHANT-ID`
+
+Create Google Pay merchant certificates
+
+```
+USAGE
+  $ bt google-pay merchants certificates create MERCHANT-ID --merchant-cert <value> --merchant-cert-password <value> [-x <value>] [-k <value>]
+    [--json]
+
+ARGUMENTS
+  MERCHANT-ID  Google Pay merchant id
+
+FLAGS
+  -k, --api-key=<value>             private API key used for API authentication
+  -x, --management-key=<value>      management key used for API authentication
+  --json                            output results as JSON
+  --merchant-cert=<value>           (required) path to merchant certificate file
+  --merchant-cert-password=<value>  (required) password for the merchant certificate
+
+DESCRIPTION
+  Create Google Pay merchant certificates
+
+EXAMPLES
+  $ bt google-pay merchants certificates create merch-123
+```
+
+## `bt google-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID`
+
+Delete Google Pay merchant certificates
+
+```
+USAGE
+  $ bt google-pay merchants certificates delete MERCHANT-ID CERTIFICATE-ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  MERCHANT-ID     Google Pay merchant id
+  CERTIFICATE-ID  certificate id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete Google Pay merchant certificates
+
+EXAMPLES
+  $ bt google-pay merchants certificates delete merch-123 cert-456
+```
+
+## `bt google-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID`
+
+Get Google Pay merchant certificates
+
+```
+USAGE
+  $ bt google-pay merchants certificates get MERCHANT-ID CERTIFICATE-ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  MERCHANT-ID     Google Pay merchant id
+  CERTIFICATE-ID  certificate id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get Google Pay merchant certificates
+
+EXAMPLES
+  $ bt google-pay merchants certificates get merch-123 cert-456
+```
+
+## `bt google-pay merchants create`
+
+Create a Google Pay merchant
+
+```
+USAGE
+  $ bt google-pay merchants create --merchant-identifier <value> [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>          private API key used for API authentication
+  -x, --management-key=<value>   management key used for API authentication
+  --json                         output results as JSON
+  --merchant-identifier=<value>  (required) merchant identifier
+
+DESCRIPTION
+  Create a Google Pay merchant
+
+EXAMPLES
+  $ bt google-pay merchants create
+```
+
+## `bt google-pay merchants delete ID`
+
+Delete a Google Pay merchant
+
+```
+USAGE
+  $ bt google-pay merchants delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Google Pay merchant id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a Google Pay merchant
+
+EXAMPLES
+  $ bt google-pay merchants delete merch-123
+```
+
+## `bt google-pay merchants get ID`
+
+Get a Google Pay merchant by ID
+
+```
+USAGE
+  $ bt google-pay merchants get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Google Pay merchant id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a Google Pay merchant by ID
+
+EXAMPLES
+  $ bt google-pay merchants get merch-123
+```
+
+## `bt keys`
+
+List client encryption keys
+
+```
+USAGE
+  $ bt keys [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List client encryption keys
+
+EXAMPLES
+  $ bt keys
+```
+
+_See code: [dist/commands/keys/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/keys/index.ts)_
+
+## `bt keys create`
+
+Create a new client encryption key
+
+```
+USAGE
+  $ bt keys create [-x <value>] [--json] [--expires-at <value>]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --expires-at=<value>          expiration date for the key
+  --json                        output results as JSON
+
+DESCRIPTION
+  Create a new client encryption key
+
+EXAMPLES
+  $ bt keys create
+```
+
+## `bt keys delete ID`
+
+Delete a client encryption key
+
+```
+USAGE
+  $ bt keys delete ID [-x <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Key id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a client encryption key
+
+EXAMPLES
+  $ bt keys delete key-123
+```
+
+## `bt logs`
+
+List audit logs
+
+```
+USAGE
+  $ bt logs [-x <value>] [--json] [--entity-type <value>] [--entity-id <value>] [--start-date <value>]
+    [--end-date <value>]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --end-date=<value>            filter by end date
+  --entity-id=<value>           filter by entity id
+  --entity-type=<value>         filter by entity type
+  --json                        output results as JSON
+  --start-date=<value>          filter by start date
+
+DESCRIPTION
+  List audit logs
+
+EXAMPLES
+  $ bt logs
+```
+
+_See code: [dist/commands/logs/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/logs/index.ts)_
+
+## `bt logs entity-types`
+
+List log entity types
+
+```
+USAGE
+  $ bt logs entity-types [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List log entity types
+
+EXAMPLES
+  $ bt logs entity-types
+```
+
+## `bt network-tokens create`
+
+Create a network token
+
+```
+USAGE
+  $ bt network-tokens create [-x <value>] [-k <value>] [--json] [--token-id <value>] [--token-intent-id <value>] [--data
+    <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                card data as JSON string
+  --file=<value>                path to JSON file containing card data
+  --json                        output results as JSON
+  --token-id=<value>            token ID to use
+  --token-intent-id=<value>     token intent ID to use
+
+DESCRIPTION
+  Create a network token
+
+EXAMPLES
+  $ bt network-tokens create --token-id tok-123
+```
+
+## `bt network-tokens cryptogram ID`
+
+Get a network token cryptogram
+
+```
+USAGE
+  $ bt network-tokens cryptogram ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Network token id
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a network token cryptogram
+
+EXAMPLES
+  $ bt network-tokens cryptogram nt-123
+```
+
+## `bt network-tokens delete ID`
+
+Delete a network token
+
+```
+USAGE
+  $ bt network-tokens delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Network token id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a network token
+
+EXAMPLES
+  $ bt network-tokens delete nt-123
+```
+
+## `bt network-tokens get ID`
+
+Get a network token by ID
+
+```
+USAGE
+  $ bt network-tokens get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Network token id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a network token by ID
+
+EXAMPLES
+  $ bt network-tokens get nt-123
+```
+
+## `bt network-tokens resume ID`
+
+Resume a network token
+
+```
+USAGE
+  $ bt network-tokens resume ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Network token id to resume
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Resume a network token
+
+EXAMPLES
+  $ bt network-tokens resume nt-123
+```
+
+## `bt network-tokens suspend ID`
+
+Suspend a network token
+
+```
+USAGE
+  $ bt network-tokens suspend ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Network token id to suspend
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Suspend a network token
+
+EXAMPLES
+  $ bt network-tokens suspend nt-123
+```
+
 ## `bt proxies`
 
 List Proxies. Requires `proxy:read` Management Application permission
 
 ```
 USAGE
-  $ bt proxies -x <value> [-p <value>]
+  $ bt proxies [-x <value>] [--json] [-p <value>] [-s <value>]
 
 FLAGS
   -p, --page=<value>            [default: 1] Proxies list page to fetch
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   List Proxies. Requires `proxy:read` Management Application permission
@@ -151,7 +1382,7 @@ EXAMPLES
   $ bt proxies
 ```
 
-_See code: [dist/commands/proxies/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v3.0.0/dist/commands/proxies/index.ts)_
+_See code: [dist/commands/proxies/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/proxies/index.ts)_
 
 ## `bt proxies create`
 
@@ -159,10 +1390,10 @@ Creates a new Pre-Configured Proxy. Requires `proxy:create` Management Applicati
 
 ```
 USAGE
-  $ bt proxies create -x <value> [-n <value>] [-u <value>] [-q <value>] [-s <value>] [-i <value>] [-c <value>] [-a]
-    [--request-transform-image node-bt|node22] [--request-transform-package-json <value>] [--request-transform-timeout
-    <value>] [--request-transform-warm-concurrency <value>] [--request-transform-resources standard|large|xlarge]
-    [--request-transform-permissions <value>] [--response-transform-image node-bt|node22]
+  $ bt proxies create [-x <value>] [--json] [-n <value>] [-u <value>] [-q <value>] [-s <value>] [-i <value>] [-c
+    <value>] [-a] [--request-transform-image node-bt|node22] [--request-transform-package-json <value>]
+    [--request-transform-timeout <value>] [--request-transform-warm-concurrency <value>] [--request-transform-resources
+    standard|large|xlarge] [--request-transform-permissions <value>] [--response-transform-image node-bt|node22]
     [--response-transform-package-json <value>] [--response-transform-timeout <value>]
     [--response-transform-warm-concurrency <value>] [--response-transform-resources standard|large|xlarge]
     [--response-transform-permissions <value>] [--async]
@@ -176,9 +1407,10 @@ FLAGS
   -q, --request-transform-code=<value>           path to JavaScript file containing a Request Transform code
   -s, --response-transform-code=<value>          path to JavaScript file containing a Response Transform code
   -u, --destination-url=<value>                  URL to which requests will be proxied
-  -x, --management-key=<value>                   (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>                   management key used for connecting with the reactor / proxy
   --async                                        do not wait for proxy to be ready (requires at least one transform with
                                                  node22)
+  --json                                         output results as JSON
   --request-transform-image=<option>             request-transform runtime image (node-bt|node22)
                                                  <options: node-bt|node22>
   --request-transform-package-json=<value>       path to runtime package.json JSON file (top-level dependencies
@@ -236,14 +1468,15 @@ Deletes a Proxy. Requires `proxy:delete` Management Application permissions
 
 ```
 USAGE
-  $ bt proxies delete ID -x <value> [-y]
+  $ bt proxies delete ID [-x <value>] [--json] [-y]
 
 ARGUMENTS
   ID  Proxy id to delete
 
 FLAGS
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   -y, --yes                     auto confirm the operation
+  --json                        output results as JSON
 
 DESCRIPTION
   Deletes a Proxy. Requires `proxy:delete` Management Application permissions
@@ -252,27 +1485,56 @@ EXAMPLES
   $ bt proxies delete 03858bf5-32d3-4a2e-b74b-daeea0883bca
 ```
 
-## `bt proxies logs [ID]`
+## `bt proxies invoke`
+
+Invokes a Proxy
+
+```
+USAGE
+  $ bt proxies invoke [-x <value>] [-k <value>] [--json] [--method GET|POST|PUT|PATCH|DELETE] [--proxy-url <value>]
+    [--proxy-key <value>] [--data <value>] [--file <value>] [--path <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                request body as JSON string
+  --file=<value>                path to a JSON file containing the request body
+  --json                        output results as JSON
+  --method=<option>             [default: POST] HTTP method to use
+                                <options: GET|POST|PUT|PATCH|DELETE>
+  --path=<value>                additional path to append to the proxy endpoint
+  --proxy-key=<value>           key for pre-configured proxy
+  --proxy-url=<value>           destination URL for ephemeral proxy
+
+DESCRIPTION
+  Invokes a Proxy
+
+EXAMPLES
+  $ bt proxies invoke --proxy-key proxy-key-123 --data '{"key": "value"}'
+
+  $ bt proxies invoke --proxy-url https://example.com/api --method GET
+```
+
+## `bt proxies logs ID`
 
 Display live Proxy Transform logs output. Requires `proxy:update` Management Application permissions
 
 ```
 USAGE
-  $ bt proxies logs [ID] -x <value> [-p <value>]
+  $ bt proxies logs ID [-x <value>] [--json] [-p <value>]
 
 ARGUMENTS
   ID  Proxy id to connect to
 
 FLAGS
   -p, --port=<value>            [default: 8220] port to listen for incoming logs
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   Display live Proxy Transform logs output. Requires `proxy:update` Management Application permissions
 
 EXAMPLES
-  $ bt proxies logs
-
   $ bt proxies logs 03858bf5-32d3-4a2e-b74b-daeea0883bca
 
   $ bt proxies logs 03858bf5-32d3-4a2e-b74b-daeea0883bca -p 3000
@@ -284,8 +1546,8 @@ Updates an existing Pre-Configured Proxy. Requires `proxy:update` Management App
 
 ```
 USAGE
-  $ bt proxies update ID -x <value> [-n <value>] [-u <value>] [-q <value>] [-s <value>] [-i <value>] [-c <value>]
-    [-a] [--request-transform-image node-bt|node22] [--request-transform-package-json <value>]
+  $ bt proxies update ID [-x <value>] [--json] [-n <value>] [-u <value>] [-q <value>] [-s <value>] [-i <value>] [-c
+    <value>] [-a] [--request-transform-image node-bt|node22] [--request-transform-package-json <value>]
     [--request-transform-timeout <value>] [--request-transform-warm-concurrency <value>] [--request-transform-resources
     standard|large|xlarge] [--request-transform-permissions <value>] [--response-transform-image node-bt|node22]
     [--response-transform-package-json <value>] [--response-transform-timeout <value>]
@@ -306,9 +1568,10 @@ FLAGS
   -s, --response-transform-code=<value>          path to JavaScript file containing a Response Transform code
   -u, --destination-url=<value>                  URL to which requests will be proxied
   -w, --watch                                    Watch for changes in informed files
-  -x, --management-key=<value>                   (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>                   management key used for connecting with the reactor / proxy
   --async                                        do not wait for proxy to be ready (requires at least one transform with
                                                  node22)
+  --json                                         output results as JSON
   --request-transform-image=<option>             request-transform runtime image (node-bt|node22)
                                                  <options: node-bt|node22>
   --request-transform-package-json=<value>       path to runtime package.json JSON file (top-level dependencies
@@ -365,11 +1628,13 @@ List Reactors. Requires `reactor:read` Management Application permission
 
 ```
 USAGE
-  $ bt reactors -x <value> [-p <value>]
+  $ bt reactors [-x <value>] [--json] [-p <value>] [-s <value>]
 
 FLAGS
   -p, --page=<value>            [default: 1] Reactors list page to fetch
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   List Reactors. Requires `reactor:read` Management Application permission
@@ -378,7 +1643,7 @@ EXAMPLES
   $ bt reactors
 ```
 
-_See code: [dist/commands/reactors/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v3.0.0/dist/commands/reactors/index.ts)_
+_See code: [dist/commands/reactors/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/reactors/index.ts)_
 
 ## `bt reactors create`
 
@@ -386,19 +1651,20 @@ Creates a new Reactor. Requires `reactor:create` Management Application permissi
 
 ```
 USAGE
-  $ bt reactors create -x <value> [-n <value>] [-c <value>] [-i <value>] [-r <value>] [--image node-bt|node22]
-    [--package-json <value>] [--timeout <value>] [--warm-concurrency <value>] [--resources standard|large|xlarge]
-    [--permissions <value>] [--async]
+  $ bt reactors create [-x <value>] [--json] [-n <value>] [-c <value>] [-i <value>] [-r <value>] [--image
+    node-bt|node22] [--package-json <value>] [--timeout <value>] [--warm-concurrency <value>] [--resources
+    standard|large|xlarge] [--permissions <value>] [--async]
 
 FLAGS
   -c, --configuration=<value>   path to configuration file (.env format) to use in the Reactor
   -i, --application-id=<value>  application ID to use in the Reactor
   -n, --name=<value>            name of the Reactor
   -r, --code=<value>            path to JavaScript file containing the Reactor code
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   --async                       do not wait for resource to be ready (node22 only)
   --image=<option>              runtime image (node-bt|node22)
                                 <options: node-bt|node22>
+  --json                        output results as JSON
   --package-json=<value>        path to runtime package.json JSON file (top-level dependencies required; supports
                                 resolutions or overrides fallback; pinned versions required) (node22 only)
   --permissions=<value>...      permission to grant, repeatable (node22 only)
@@ -432,14 +1698,15 @@ Deletes a Reactor. Requires `reactor:delete` Management Application permissions
 
 ```
 USAGE
-  $ bt reactors delete ID -x <value> [-y]
+  $ bt reactors delete ID [-x <value>] [--json] [-y]
 
 ARGUMENTS
   ID  Reactor id to delete
 
 FLAGS
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   -y, --yes                     auto confirm the operation
+  --json                        output results as JSON
 
 DESCRIPTION
   Deletes a Reactor. Requires `reactor:delete` Management Application permissions
@@ -448,27 +1715,104 @@ EXAMPLES
   $ bt reactors delete 03858bf5-32d3-4a2e-b74b-daeea0883bca
 ```
 
-## `bt reactors logs [ID]`
+## `bt reactors get-result ID REQUEST-ID`
+
+Gets the result of an asynchronous Reactor invocation
+
+```
+USAGE
+  $ bt reactors get-result ID REQUEST-ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID          Reactor ID
+  REQUEST-ID  Async request ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Gets the result of an asynchronous Reactor invocation
+
+EXAMPLES
+  $ bt reactors get-result reactor-123 request-456
+```
+
+## `bt reactors invoke ID`
+
+Invokes a Reactor synchronously
+
+```
+USAGE
+  $ bt reactors invoke ID [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+ARGUMENTS
+  ID  Reactor ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                request body as JSON string
+  --file=<value>                path to a JSON file containing the request body
+  --json                        output results as JSON
+
+DESCRIPTION
+  Invokes a Reactor synchronously
+
+EXAMPLES
+  $ bt reactors invoke reactor-123 --data '{"key": "value"}'
+
+  $ bt reactors invoke reactor-123 --file ./request.json
+```
+
+## `bt reactors invoke-async ID`
+
+Invokes a Reactor asynchronously
+
+```
+USAGE
+  $ bt reactors invoke-async ID [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+ARGUMENTS
+  ID  Reactor ID
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                request body as JSON string
+  --file=<value>                path to a JSON file containing the request body
+  --json                        output results as JSON
+
+DESCRIPTION
+  Invokes a Reactor asynchronously
+
+EXAMPLES
+  $ bt reactors invoke-async reactor-123 --data '{"key": "value"}'
+
+  $ bt reactors invoke-async reactor-123 --file ./request.json
+```
+
+## `bt reactors logs ID`
 
 Display live Reactor logs output. Requires `reactor:update` Management Application permissions
 
 ```
 USAGE
-  $ bt reactors logs [ID] -x <value> [-p <value>]
+  $ bt reactors logs ID [-x <value>] [--json] [-p <value>]
 
 ARGUMENTS
   ID  Reactor id to connect to
 
 FLAGS
   -p, --port=<value>            [default: 8220] port to listen for incoming logs
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
 
 DESCRIPTION
   Display live Reactor logs output. Requires `reactor:update` Management Application permissions
 
 EXAMPLES
-  $ bt reactors logs
-
   $ bt reactors logs 03858bf5-32d3-4a2e-b74b-daeea0883bca
 
   $ bt reactors logs 03858bf5-32d3-4a2e-b74b-daeea0883bca -p 3000
@@ -480,9 +1824,9 @@ Updates an existing Reactor. Requires `reactor:update` Management Application pe
 
 ```
 USAGE
-  $ bt reactors update ID -x <value> [-n <value>] [-c <value>] [-i <value>] [-r <value>] [--image node-bt|node22]
-    [--package-json <value>] [--timeout <value>] [--warm-concurrency <value>] [--resources standard|large|xlarge]
-    [--permissions <value>] [--async] [-w] [-l]
+  $ bt reactors update ID [-x <value>] [--json] [-n <value>] [-c <value>] [-i <value>] [-r <value>] [--image
+    node-bt|node22] [--package-json <value>] [--timeout <value>] [--warm-concurrency <value>] [--resources
+    standard|large|xlarge] [--permissions <value>] [--async] [-w] [-l]
 
 ARGUMENTS
   ID  Reactor id to update
@@ -494,10 +1838,11 @@ FLAGS
   -n, --name=<value>            name of the Reactor
   -r, --code=<value>            path to JavaScript file containing the Reactor code
   -w, --watch                   Watch for changes in informed files
-  -x, --management-key=<value>  (required) management key used for connecting with the reactor / proxy
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
   --async                       do not wait for resource to be ready (node22 only)
   --image=<option>              runtime image (node-bt|node22)
                                 <options: node-bt|node22>
+  --json                        output results as JSON
   --package-json=<value>        path to runtime package.json JSON file (top-level dependencies required; supports
                                 resolutions or overrides fallback; pinned versions required) (node22 only)
   --permissions=<value>...      permission to grant, repeatable (node22 only)
@@ -523,5 +1868,689 @@ EXAMPLES
     $ bt reactors update <reactor-id> --name "My Reactor" --code ./reactor.js --configuration ./config.env --image \
       node22 --timeout 10 --warm-concurrency 0 --resources standard --package-json ./package.json --permissions \
       token:read --permissions token:create
+```
+
+## `bt tenants delete`
+
+Delete the current tenant
+
+```
+USAGE
+  $ bt tenants delete [-x <value>] [--json] [-f]
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete the current tenant
+
+EXAMPLES
+  $ bt tenants delete
+```
+
+## `bt tenants get`
+
+Get current tenant details
+
+```
+USAGE
+  $ bt tenants get [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get current tenant details
+
+EXAMPLES
+  $ bt tenants get
+```
+
+## `bt tenants invitations`
+
+List tenant invitations
+
+```
+USAGE
+  $ bt tenants invitations [-x <value>] [--json] [-p <value>] [-s <value>]
+
+FLAGS
+  -p, --page=<value>            [default: 1] page number to fetch
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List tenant invitations
+
+EXAMPLES
+  $ bt tenants invitations
+```
+
+## `bt tenants invitations create`
+
+Create a tenant invitation
+
+```
+USAGE
+  $ bt tenants invitations create -e <value> [-x <value>] [--json] [-r <value>]
+
+FLAGS
+  -e, --email=<value>           (required) email address to invite
+  -r, --role=<value>            [default: ADMIN] role for the invitation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Create a tenant invitation
+
+EXAMPLES
+  $ bt tenants invitations create
+```
+
+## `bt tenants invitations delete ID`
+
+Delete a tenant invitation
+
+```
+USAGE
+  $ bt tenants invitations delete ID [-x <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Invitation id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a tenant invitation
+
+EXAMPLES
+  $ bt tenants invitations delete 03858bf5-32d3-4a2e-b74b-daeea0883bca
+```
+
+## `bt tenants invitations resend ID`
+
+Resend a tenant invitation
+
+```
+USAGE
+  $ bt tenants invitations resend ID [-x <value>] [--json]
+
+ARGUMENTS
+  ID  Invitation id to resend
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Resend a tenant invitation
+
+EXAMPLES
+  $ bt tenants invitations resend 03858bf5-32d3-4a2e-b74b-daeea0883bca
+```
+
+## `bt tenants members`
+
+List tenant members
+
+```
+USAGE
+  $ bt tenants members [-x <value>] [--json] [-p <value>] [-s <value>] [--user-id <value>]
+
+FLAGS
+  -p, --page=<value>            [default: 1] page number to fetch
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+  --user-id=<value>             filter by user ID
+
+DESCRIPTION
+  List tenant members
+
+EXAMPLES
+  $ bt tenants members
+```
+
+## `bt tenants members delete ID`
+
+Delete a tenant member
+
+```
+USAGE
+  $ bt tenants members delete ID [-x <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Member id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a tenant member
+
+EXAMPLES
+  $ bt tenants members delete 03858bf5-32d3-4a2e-b74b-daeea0883bca
+```
+
+## `bt tenants members update ID`
+
+Update a tenant member
+
+```
+USAGE
+  $ bt tenants members update ID -r <value> [-x <value>] [--json]
+
+ARGUMENTS
+  ID  Member id to update
+
+FLAGS
+  -r, --role=<value>            (required) role for the member (ADMIN, MEMBER)
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Update a tenant member
+
+EXAMPLES
+  $ bt tenants members update
+```
+
+## `bt tenants merchants`
+
+List tenant merchants
+
+```
+USAGE
+  $ bt tenants merchants [-x <value>] [--json] [-p <value>] [-s <value>]
+
+FLAGS
+  -p, --page=<value>            [default: 1] page number to fetch
+  -s, --size=<value>            [default: 20] number of items per page
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List tenant merchants
+
+EXAMPLES
+  $ bt tenants merchants
+```
+
+## `bt tenants update`
+
+Update the current tenant
+
+```
+USAGE
+  $ bt tenants update [-x <value>] [--json] [-n <value>] [--fingerprint-tokens <value>] [--deduplicate-tokens
+    <value>] [--disable-ephemeral-proxy <value>]
+
+FLAGS
+  -n, --name=<value>                 name of the Tenant
+  -x, --management-key=<value>       management key used for connecting with the reactor / proxy
+  --deduplicate-tokens=<value>       enable or disable token deduplication
+  --disable-ephemeral-proxy=<value>  enable or disable ephemeral proxy
+  --fingerprint-tokens=<value>       enable or disable token fingerprinting
+  --json                             output results as JSON
+
+DESCRIPTION
+  Update the current tenant
+
+EXAMPLES
+  $ bt tenants update
+```
+
+## `bt tenants usage`
+
+Get tenant usage report
+
+```
+USAGE
+  $ bt tenants usage [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get tenant usage report
+
+EXAMPLES
+  $ bt tenants usage
+```
+
+## `bt token-intents create`
+
+Create a new token intent
+
+```
+USAGE
+  $ bt token-intents create --type <value> [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                token intent data as JSON string
+  --file=<value>                path to JSON file containing token intent data
+  --json                        output results as JSON
+  --type=<value>                (required) token intent type
+
+DESCRIPTION
+  Create a new token intent
+
+EXAMPLES
+  $ bt token-intents create --type card --data '{"number":"4242424242424242"}'
+```
+
+## `bt token-intents delete ID`
+
+Delete a token intent
+
+```
+USAGE
+  $ bt token-intents delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Token intent id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a token intent
+
+EXAMPLES
+  $ bt token-intents delete ti-123
+```
+
+## `bt token-intents get ID`
+
+Get a token intent by ID
+
+```
+USAGE
+  $ bt token-intents get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Token intent id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a token intent by ID
+
+EXAMPLES
+  $ bt token-intents get ti-123
+```
+
+## `bt tokenize`
+
+Tokenize data
+
+```
+USAGE
+  $ bt tokenize [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --data=<value>                JSON data to tokenize
+  --file=<value>                path to JSON file containing data to tokenize
+  --json                        output results as JSON
+
+DESCRIPTION
+  Tokenize data
+
+EXAMPLES
+  $ bt tokenize --data '{"type":"token","data":"secret"}'
+```
+
+_See code: [dist/commands/tokenize.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/tokenize.ts)_
+
+## `bt tokens`
+
+List tokens
+
+```
+USAGE
+  $ bt tokens [-x <value>] [-k <value>] [--json] [--container <value>] [--type <value>] [--fingerprint
+    <value>] [--size <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --container=<value>           filter by container
+  --fingerprint=<value>         filter by fingerprint
+  --json                        output results as JSON
+  --size=<value>                [default: 20] number of tokens to return
+  --type=<value>                filter by token type
+
+DESCRIPTION
+  List tokens
+
+EXAMPLES
+  $ bt tokens
+```
+
+_See code: [dist/commands/tokens/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/tokens/index.ts)_
+
+## `bt tokens create`
+
+Create a new token
+
+```
+USAGE
+  $ bt tokens create [-x <value>] [-k <value>] [--json] [--type <value>] [--data <value>] [--file <value>]
+    [--token-intent-id <value>] [--container <value>] [--metadata <value>] [--expires-at <value>]
+    [--fingerprint-expression <value>] [--deduplicate]
+
+FLAGS
+  -k, --api-key=<value>             private API key used for API authentication
+  -x, --management-key=<value>      management key used for API authentication
+  --container=<value>...            container for the token
+  --data=<value>                    token data as JSON string
+  --deduplicate                     enable token deduplication
+  --expires-at=<value>              token expiration date
+  --file=<value>                    path to JSON file containing token data
+  --fingerprint-expression=<value>  fingerprint expression
+  --json                            output results as JSON
+  --metadata=<value>...             metadata key=value pair
+  --token-intent-id=<value>         token intent ID to use
+  --type=<value>                    token type
+
+DESCRIPTION
+  Create a new token
+
+EXAMPLES
+  $ bt tokens create --type token --data '{"key":"value"}'
+```
+
+## `bt tokens delete ID`
+
+Delete a token
+
+```
+USAGE
+  $ bt tokens delete ID [-x <value>] [-k <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Token id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a token
+
+EXAMPLES
+  $ bt tokens delete tok-123
+```
+
+## `bt tokens get ID`
+
+Get a token by ID
+
+```
+USAGE
+  $ bt tokens get ID [-x <value>] [-k <value>] [--json]
+
+ARGUMENTS
+  ID  Token id to retrieve
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a token by ID
+
+EXAMPLES
+  $ bt tokens get tok-123
+```
+
+## `bt tokens search`
+
+Search tokens
+
+```
+USAGE
+  $ bt tokens search --query <value> [-x <value>] [-k <value>] [--json] [--size <value>]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+  --query=<value>               (required) search query
+  --size=<value>                [default: 20] number of tokens to return
+
+DESCRIPTION
+  Search tokens
+
+EXAMPLES
+  $ bt tokens search --query 'data:4242'
+```
+
+## `bt tokens types`
+
+List available token types
+
+```
+USAGE
+  $ bt tokens types [-x <value>] [-k <value>] [--json]
+
+FLAGS
+  -k, --api-key=<value>         private API key used for API authentication
+  -x, --management-key=<value>  management key used for API authentication
+  --json                        output results as JSON
+
+DESCRIPTION
+  List available token types
+
+EXAMPLES
+  $ bt tokens types
+```
+
+## `bt tokens update ID`
+
+Update an existing token
+
+```
+USAGE
+  $ bt tokens update ID [-x <value>] [-k <value>] [--json] [--data <value>] [--file <value>] [--container <value>]
+    [--metadata <value>] [--expires-at <value>] [--fingerprint-expression <value>] [--deduplicate]
+
+ARGUMENTS
+  ID  Token id to update
+
+FLAGS
+  -k, --api-key=<value>             private API key used for API authentication
+  -x, --management-key=<value>      management key used for API authentication
+  --container=<value>...            container for the token
+  --data=<value>                    token data as JSON string
+  --deduplicate                     enable token deduplication
+  --expires-at=<value>              token expiration date
+  --file=<value>                    path to JSON file containing token data
+  --fingerprint-expression=<value>  fingerprint expression
+  --json                            output results as JSON
+  --metadata=<value>...             metadata key=value pair
+
+DESCRIPTION
+  Update an existing token
+
+EXAMPLES
+  $ bt tokens update tok-123 --data '{"key":"new-value"}'
+```
+
+## `bt webhooks`
+
+List webhooks
+
+```
+USAGE
+  $ bt webhooks [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List webhooks
+
+EXAMPLES
+  $ bt webhooks
+```
+
+_See code: [dist/commands/webhooks/index.ts](https://github.com/Basis-Theory-Labs/basistheory-cli/blob/v4.0.0/dist/commands/webhooks/index.ts)_
+
+## `bt webhooks create`
+
+Create a new webhook
+
+```
+USAGE
+  $ bt webhooks create --name <value> --url <value> --events <value> [-x <value>] [--json] [--notify-email <value>]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --events=<value>...           (required) events to subscribe to
+  --json                        output results as JSON
+  --name=<value>                (required) name of the webhook
+  --notify-email=<value>        email to notify on webhook failure
+  --url=<value>                 (required) URL of the webhook
+
+DESCRIPTION
+  Create a new webhook
+
+EXAMPLES
+  $ bt webhooks create
+```
+
+## `bt webhooks delete ID`
+
+Delete a webhook
+
+```
+USAGE
+  $ bt webhooks delete ID [-x <value>] [--json] [-f]
+
+ARGUMENTS
+  ID  Webhook id to delete
+
+FLAGS
+  -f, --force                   force deletion without confirmation
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Delete a webhook
+
+EXAMPLES
+  $ bt webhooks delete wh-123
+```
+
+## `bt webhooks events`
+
+List available webhook event types
+
+```
+USAGE
+  $ bt webhooks events [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  List available webhook event types
+
+EXAMPLES
+  $ bt webhooks events
+```
+
+## `bt webhooks get ID`
+
+Get a webhook by ID
+
+```
+USAGE
+  $ bt webhooks get ID [-x <value>] [--json]
+
+ARGUMENTS
+  ID  Webhook id to retrieve
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Get a webhook by ID
+
+EXAMPLES
+  $ bt webhooks get wh-123
+```
+
+## `bt webhooks ping`
+
+Send a test ping to all webhooks
+
+```
+USAGE
+  $ bt webhooks ping [-x <value>] [--json]
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --json                        output results as JSON
+
+DESCRIPTION
+  Send a test ping to all webhooks
+
+EXAMPLES
+  $ bt webhooks ping
+```
+
+## `bt webhooks update ID`
+
+Update a webhook
+
+```
+USAGE
+  $ bt webhooks update ID [-x <value>] [--json] [--name <value>] [--url <value>] [--events <value>] [--notify-email
+    <value>]
+
+ARGUMENTS
+  ID  Webhook id to update
+
+FLAGS
+  -x, --management-key=<value>  management key used for connecting with the reactor / proxy
+  --events=<value>...           events to subscribe to
+  --json                        output results as JSON
+  --name=<value>                name of the webhook
+  --notify-email=<value>        email to notify on webhook failure
+  --url=<value>                 URL of the webhook
+
+DESCRIPTION
+  Update a webhook
+
+EXAMPLES
+  $ bt webhooks update wh-123
 ```
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basis-theory-labs/cli",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Basis Theory CLI tool",
   "author": "Davi Aquino @djejaquino",
   "bin": {
@@ -72,6 +72,9 @@
     "bin": "bt",
     "dirname": "bt",
     "commands": "./dist/commands",
+    "hooks": {
+      "init": "./dist/hooks/init"
+    },
     "plugins": [],
     "topicSeparator": " ",
     "topics": {
@@ -112,25 +115,25 @@
         "description": "Manage Documents"
       },
       "apple-pay": {
-        "description": "Manage Apple Pay"
+        "description": "[Beta] Manage Apple Pay"
       },
       "apple-pay domains": {
-        "description": "Manage Apple Pay Domains"
+        "description": "[Beta] Manage Apple Pay Domains"
       },
       "apple-pay merchants": {
-        "description": "Manage Apple Pay Merchants"
+        "description": "[Beta] Manage Apple Pay Merchants"
       },
       "apple-pay merchants certificates": {
-        "description": "Manage Apple Pay Merchant Certificates"
+        "description": "[Beta] Manage Apple Pay Merchant Certificates"
       },
       "google-pay": {
-        "description": "Manage Google Pay"
+        "description": "[Beta] Manage Google Pay"
       },
       "google-pay merchants": {
-        "description": "Manage Google Pay Merchants"
+        "description": "[Beta] Manage Google Pay Merchants"
       },
       "google-pay merchants certificates": {
-        "description": "Manage Google Pay Merchant Certificates"
+        "description": "[Beta] Manage Google Pay Merchant Certificates"
       },
       "account-updater": {
         "description": "Account Updater Operations"
@@ -139,16 +142,16 @@
         "description": "Manage Account Updater Batch Jobs"
       },
       "network-tokens": {
-        "description": "Manage Network Tokens"
+        "description": "[Beta] Manage Network Tokens"
       },
       "3ds": {
-        "description": "3D Secure Operations"
+        "description": "[Beta] 3D Secure Operations"
       },
       "3ds sessions": {
-        "description": "Manage 3DS Sessions"
+        "description": "[Beta] Manage 3DS Sessions"
       },
       "enrichments": {
-        "description": "Data Enrichment Operations"
+        "description": "[Beta] Data Enrichment Operations"
       },
       "connections": {
         "description": "Manage Connections"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,81 @@
       },
       "reactors": {
         "description": "Manage Reactors"
+      },
+      "tenants": {
+        "description": "Manage Tenants"
+      },
+      "tenants members": {
+        "description": "Manage Tenant Members"
+      },
+      "tenants invitations": {
+        "description": "Manage Tenant Invitations"
+      },
+      "tenants merchants": {
+        "description": "View Tenant Merchants"
+      },
+      "logs": {
+        "description": "View Audit Logs"
+      },
+      "webhooks": {
+        "description": "Manage Webhooks"
+      },
+      "keys": {
+        "description": "Manage Client Encryption Keys"
+      },
+      "tokens": {
+        "description": "Manage Tokens"
+      },
+      "token-intents": {
+        "description": "Manage Token Intents"
+      },
+      "documents": {
+        "description": "Manage Documents"
+      },
+      "apple-pay": {
+        "description": "Manage Apple Pay"
+      },
+      "apple-pay domains": {
+        "description": "Manage Apple Pay Domains"
+      },
+      "apple-pay merchants": {
+        "description": "Manage Apple Pay Merchants"
+      },
+      "apple-pay merchants certificates": {
+        "description": "Manage Apple Pay Merchant Certificates"
+      },
+      "google-pay": {
+        "description": "Manage Google Pay"
+      },
+      "google-pay merchants": {
+        "description": "Manage Google Pay Merchants"
+      },
+      "google-pay merchants certificates": {
+        "description": "Manage Google Pay Merchant Certificates"
+      },
+      "account-updater": {
+        "description": "Account Updater Operations"
+      },
+      "account-updater jobs": {
+        "description": "Manage Account Updater Batch Jobs"
+      },
+      "network-tokens": {
+        "description": "Manage Network Tokens"
+      },
+      "3ds": {
+        "description": "3D Secure Operations"
+      },
+      "3ds sessions": {
+        "description": "Manage 3DS Sessions"
+      },
+      "enrichments": {
+        "description": "Data Enrichment Operations"
+      },
+      "connections": {
+        "description": "Manage Connections"
+      },
+      "connections stripe-forward": {
+        "description": "Stripe Forward Connection"
       }
     }
   },

--- a/scripts/test-endpoints.sh
+++ b/scripts/test-endpoints.sh
@@ -8,11 +8,15 @@
 #   export BT_API_KEY="your_private_api_key"
 #   ./scripts/test-endpoints.sh
 #
+# Keys can also be provided via ~/.basistheory/cli.json:
+#   { "managementApiKey": "...", "apiKey": "...", "apiBaseUrl": "..." }
+#
 # Options:
-#   --skip-destructive   Skip delete/destroy operations
 #   --json               Pass --json to all commands
 #   --verbose            Print full command output
 #   --section SECTION    Run only a specific section (tenants, logs, webhooks, keys, tokens, etc.)
+#
+# All created resources are automatically cleaned up on exit (including Ctrl-C).
 #
 
 set -euo pipefail
@@ -25,21 +29,169 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-SKIP_DESTRUCTIVE=false
 JSON_FLAG=""
 VERBOSE=false
 SECTION=""
 PASS_COUNT=0
 FAIL_COUNT=0
 SKIP_COUNT=0
+LAST_TEST_PASSED=false
 
 BT="./bin/run"
+
+# ─── Cleanup Tracking ──────────────────────────────────────────────────────────
+# Resources created during the run are tracked here and cleaned up on exit.
+
+# Using declare -a ensures arrays are defined (prevents unbound variable errors with set -u)
+declare -a CLEANUP_INVITATIONS=()
+declare -a CLEANUP_WEBHOOKS=()
+declare -a CLEANUP_KEYS=()
+declare -a CLEANUP_TOKENS=()
+declare -a CLEANUP_TOKEN_INTENTS=()
+declare -a CLEANUP_DOCUMENTS=()
+declare -a CLEANUP_NETWORK_TOKENS=()
+declare -a CLEANUP_REACTORS=()
+declare -a CLEANUP_TEMP_FILES=()
+ORIGINAL_TENANT_NAME=""
+CONFIG_BACKUP=""
+CONFIG_NEEDS_RESTORE=false
+ORIG_MGMT_KEY_FOR_RESTORE=""
+ORIG_API_KEY_FOR_RESTORE=""
+
+cleanup() {
+  echo ""
+  echo -e "${BLUE}━━━ Cleanup ━━━${NC}"
+
+  # Restore config file if needed
+  if $CONFIG_NEEDS_RESTORE; then
+    echo -e "  Restoring ~/.basistheory/cli.json..."
+    echo "$CONFIG_BACKUP" > "$CONFIG_FILE"
+    if [[ -n "$ORIG_MGMT_KEY_FOR_RESTORE" ]]; then
+      export BT_MANAGEMENT_KEY="$ORIG_MGMT_KEY_FOR_RESTORE"
+    fi
+    if [[ -n "$ORIG_API_KEY_FOR_RESTORE" ]]; then
+      export BT_API_KEY="$ORIG_API_KEY_FOR_RESTORE"
+    fi
+    CONFIG_NEEDS_RESTORE=false
+  fi
+
+  # Restore tenant name
+  if [[ -n "$ORIGINAL_TENANT_NAME" ]]; then
+    printf "  %-60s " "Restore tenant name"
+    if $BT tenants update --name "$ORIGINAL_TENANT_NAME" >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed (manual restore needed)${NC}"
+    fi
+  fi
+
+  local had_work=false
+
+  # Delete resources in reverse order of dependency
+  for id in ${CLEANUP_NETWORK_TOKENS[@]+"${CLEANUP_NETWORK_TOKENS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete network token $id"
+    if $BT network-tokens delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_REACTORS[@]+"${CLEANUP_REACTORS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete reactor $id"
+    if $BT reactors delete "$id" --yes >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_DOCUMENTS[@]+"${CLEANUP_DOCUMENTS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete document $id"
+    if $BT documents delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_TOKEN_INTENTS[@]+"${CLEANUP_TOKEN_INTENTS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete token intent $id"
+    if $BT token-intents delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_TOKENS[@]+"${CLEANUP_TOKENS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete token $id"
+    if $BT tokens delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_KEYS[@]+"${CLEANUP_KEYS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete client key $id"
+    if $BT keys delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_WEBHOOKS[@]+"${CLEANUP_WEBHOOKS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete webhook $id"
+    if $BT webhooks delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  for id in ${CLEANUP_INVITATIONS[@]+"${CLEANUP_INVITATIONS[@]}"}; do
+    [[ -z "$id" ]] && continue
+    had_work=true
+    printf "  %-60s " "Delete invitation $id"
+    if $BT tenants invitations delete "$id" --force >/dev/null 2>&1; then
+      echo -e "${GREEN}done${NC}"
+    else
+      echo -e "${YELLOW}failed${NC}"
+    fi
+  done
+
+  # Remove temp files
+  for f in ${CLEANUP_TEMP_FILES[@]+"${CLEANUP_TEMP_FILES[@]}"}; do
+    rm -f "$f"
+  done
+
+  if ! $had_work && [[ -z "$ORIGINAL_TENANT_NAME" ]]; then
+    echo -e "  ${GREEN}Nothing to clean up.${NC}"
+  fi
+}
+
+trap cleanup EXIT
 
 # ─── Parse Arguments ────────────────────────────────────────────────────────────
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --skip-destructive) SKIP_DESTRUCTIVE=true; shift ;;
     --json) JSON_FLAG="--json"; shift ;;
     --verbose) VERBOSE=true; shift ;;
     --section) SECTION="$2"; shift 2 ;;
@@ -49,14 +201,39 @@ done
 
 # ─── Validation ─────────────────────────────────────────────────────────────────
 
-if [[ -z "${BT_MANAGEMENT_KEY:-}" ]]; then
-  echo -e "${RED}Error: BT_MANAGEMENT_KEY environment variable is required${NC}"
-  echo "Export it before running: export BT_MANAGEMENT_KEY=your_key"
+CONFIG_FILE="$HOME/.basistheory/cli.json"
+
+# Check for keys in env vars OR config file
+HAS_MANAGEMENT_KEY=false
+HAS_API_KEY=false
+
+if [[ -n "${BT_MANAGEMENT_KEY:-}" ]]; then
+  HAS_MANAGEMENT_KEY=true
+elif [[ -f "$CONFIG_FILE" ]]; then
+  CONFIG_MGMT_KEY=$(grep -o '"managementApiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"' || true)
+  if [[ -n "$CONFIG_MGMT_KEY" ]]; then
+    HAS_MANAGEMENT_KEY=true
+  fi
+fi
+
+if [[ -n "${BT_API_KEY:-}" ]]; then
+  HAS_API_KEY=true
+elif [[ -f "$CONFIG_FILE" ]]; then
+  CONFIG_API_KEY=$(grep -o '"apiKey"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"' || true)
+  if [[ -n "$CONFIG_API_KEY" ]]; then
+    HAS_API_KEY=true
+  fi
+fi
+
+if ! $HAS_MANAGEMENT_KEY; then
+  echo -e "${RED}Error: Management key is required via BT_MANAGEMENT_KEY env var or ~/.basistheory/cli.json${NC}"
+  echo "Either: export BT_MANAGEMENT_KEY=your_key"
+  echo "    or: echo '{\"managementApiKey\": \"your_key\"}' > ~/.basistheory/cli.json"
   exit 1
 fi
 
-if [[ -z "${BT_API_KEY:-}" ]]; then
-  echo -e "${YELLOW}Warning: BT_API_KEY not set. Tokenization commands will use BT_MANAGEMENT_KEY.${NC}"
+if ! $HAS_API_KEY; then
+  echo -e "${YELLOW}Warning: API key not found in BT_API_KEY or ~/.basistheory/cli.json. Tokenization commands will use management key.${NC}"
 fi
 
 # ─── Helpers ────────────────────────────────────────────────────────────────────
@@ -68,8 +245,10 @@ run_test() {
 
   printf "  %-60s " "$description"
 
-  local output
-  if output=$("${cmd[@]}" 2>&1); then
+  local output exit_code=0
+  output=$("${cmd[@]}" 2>&1) || exit_code=$?
+
+  if [[ $exit_code -eq 0 ]]; then
     echo -e "${GREEN}PASS${NC}"
     PASS_COUNT=$((PASS_COUNT + 1))
     if $VERBOSE; then
@@ -77,14 +256,22 @@ run_test() {
     fi
     # Store last output for chaining
     LAST_OUTPUT="$output"
-    return 0
+    LAST_TEST_PASSED=true
+  elif echo "$output" | grep -qi '\[403\]\|Forbidden\|missing.permission\|Missing permission'; then
+    echo -e "${YELLOW}SKIP (missing permission)${NC}"
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    LAST_OUTPUT=""
+    LAST_TEST_PASSED=false
   else
     echo -e "${RED}FAIL${NC}"
     FAIL_COUNT=$((FAIL_COUNT + 1))
     echo "$output" | sed 's/^/    │ /' | head -5
     LAST_OUTPUT=""
-    return 1
+    LAST_TEST_PASSED=false
   fi
+  # Always return 0 so set -e doesn't exit the script.
+  # Use LAST_TEST_PASSED for conditional chaining instead.
+  return 0
 }
 
 skip_test() {
@@ -105,24 +292,82 @@ should_run() {
 
 extract_id() {
   # Extract an ID from JSON output (first "id" field found)
-  echo "$LAST_OUTPUT" | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"'
+  local val
+  val=$(echo "$LAST_OUTPUT" | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"' || true)
+  echo "$val"
 }
 
 extract_field() {
   local field="$1"
-  echo "$LAST_OUTPUT" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | grep -o '"[^"]*"$' | tr -d '"'
+  local val
+  val=$(echo "$LAST_OUTPUT" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | grep -o '"[^"]*"$' | tr -d '"' || true)
+  echo "$val"
 }
 
 # ─── Build ──────────────────────────────────────────────────────────────────────
 
 section_header "Building CLI"
 run_test "yarn build" yarn build
+if ! $LAST_TEST_PASSED; then
+  echo -e "${RED}Build failed. Cannot continue.${NC}"
+  exit 1
+fi
 
 echo ""
 echo -e "${BLUE}Starting endpoint tests...${NC}"
-echo -e "  Management Key: ${BT_MANAGEMENT_KEY:0:10}..."
+if [[ -n "${BT_MANAGEMENT_KEY:-}" ]]; then
+  echo -e "  Management Key: ${BT_MANAGEMENT_KEY:0:10}... (env)"
+elif $HAS_MANAGEMENT_KEY; then
+  echo -e "  Management Key: (from ~/.basistheory/cli.json)"
+fi
 if [[ -n "${BT_API_KEY:-}" ]]; then
-  echo -e "  API Key: ${BT_API_KEY:0:10}..."
+  echo -e "  API Key: ${BT_API_KEY:0:10}... (env)"
+elif $HAS_API_KEY; then
+  echo -e "  API Key: (from ~/.basistheory/cli.json)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIG FILE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if should_run "config"; then
+  section_header "Config File (~/.basistheory/cli.json)"
+
+  run_test "Config directory exists" \
+    test -d "$HOME/.basistheory"
+
+  run_test "Config file exists after CLI init" \
+    test -f "$CONFIG_FILE"
+
+  run_test "Config file is valid JSON" \
+    python3 -c "import json; json.load(open('$CONFIG_FILE'))"
+
+  # Test that CLI reads from config file (backup and restore env vars)
+  if [[ -n "${BT_MANAGEMENT_KEY:-}" ]]; then
+    # Set up trap-safe restore state
+    CONFIG_BACKUP=$(cat "$CONFIG_FILE")
+    ORIG_MGMT_KEY_FOR_RESTORE="${BT_MANAGEMENT_KEY}"
+    ORIG_API_KEY_FOR_RESTORE="${BT_API_KEY:-}"
+    CONFIG_NEEDS_RESTORE=true
+
+    # Write management key to config, unset env var, and verify CLI still works
+    echo "{\"managementApiKey\": \"$BT_MANAGEMENT_KEY\"}" > "$CONFIG_FILE"
+    unset BT_MANAGEMENT_KEY 2>/dev/null || true
+    unset BT_API_KEY 2>/dev/null || true
+
+    run_test "CLI reads managementApiKey from config file" \
+      $BT tenants get $JSON_FLAG
+
+    # Restore immediately (trap is a safety net)
+    echo "$CONFIG_BACKUP" > "$CONFIG_FILE"
+    export BT_MANAGEMENT_KEY="$ORIG_MGMT_KEY_FOR_RESTORE"
+    if [[ -n "$ORIG_API_KEY_FOR_RESTORE" ]]; then
+      export BT_API_KEY="$ORIG_API_KEY_FOR_RESTORE"
+    fi
+    CONFIG_NEEDS_RESTORE=false
+  else
+    skip_test "CLI reads from config file — BT_MANAGEMENT_KEY not in env to test with"
+  fi
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -137,11 +382,16 @@ if should_run "tenants"; then
   run_test "Get current tenant" \
     $BT tenants get $JSON_FLAG
 
+  # Capture original tenant name so cleanup can restore it
+  if $LAST_TEST_PASSED; then
+    ORIGINAL_TENANT_NAME=$(extract_field "name")
+  fi
+
   run_test "Get tenant usage report" \
     $BT tenants usage $JSON_FLAG
 
   run_test "Update tenant name" \
-    $BT tenants update --name "CLI Test Tenant" $JSON_FLAG || true
+    $BT tenants update --name "CLI Test Tenant" $JSON_FLAG
 
   # Members
   section_header "Tenant Members"
@@ -158,21 +408,31 @@ if should_run "tenants"; then
   run_test "List tenant invitations" \
     $BT tenants invitations $JSON_FLAG
 
+  # Clean up stale cli-test invitations from previous runs
+  if $LAST_TEST_PASSED && [[ -n "$LAST_OUTPUT" ]]; then
+    STALE_IDS=$(echo "$LAST_OUTPUT" | grep -o '[0-9a-f\-]\{36\}.*cli-test-' | grep -o '^[0-9a-f\-]\{36\}' || true)
+    for stale_id in $STALE_IDS; do
+      $BT tenants invitations delete "$stale_id" --force >/dev/null 2>&1 || true
+    done
+  fi
+
   INVITATION_ID=""
-  if run_test "Create tenant invitation" \
-    $BT tenants invitations create --email "cli-test-$(date +%s)@example.com" --role ADMIN $JSON_FLAG; then
+  run_test "Create tenant invitation" \
+    $BT tenants invitations create --email "cli-test-$(date +%s)@example.com" --role ADMIN $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     INVITATION_ID=$(extract_id)
+    [[ -n "$INVITATION_ID" ]] && CLEANUP_INVITATIONS+=("$INVITATION_ID")
   fi
 
   if [[ -n "$INVITATION_ID" ]]; then
     run_test "Resend invitation ($INVITATION_ID)" \
-      $BT tenants invitations resend "$INVITATION_ID" $JSON_FLAG || true
+      $BT tenants invitations resend "$INVITATION_ID" $JSON_FLAG
 
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete invitation ($INVITATION_ID)" \
-        $BT tenants invitations delete "$INVITATION_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete invitation (--skip-destructive)"
+    run_test "Delete invitation ($INVITATION_ID)" \
+      $BT tenants invitations delete "$INVITATION_ID" --force $JSON_FLAG
+    # Remove from cleanup if inline delete succeeded
+    if $LAST_TEST_PASSED; then
+      CLEANUP_INVITATIONS=("${CLEANUP_INVITATIONS[@]/$INVITATION_ID/}")
     fi
   fi
 
@@ -210,14 +470,16 @@ if should_run "webhooks"; then
     $BT webhooks events $JSON_FLAG
 
   WEBHOOK_ID=""
-  if run_test "Create webhook" \
+  run_test "Create webhook" \
     $BT webhooks create \
       --name "CLI Test Webhook $(date +%s)" \
       --url "https://httpbin.org/post" \
       --events "token.created" \
       --events "token.deleted" \
-      $JSON_FLAG; then
+      $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     WEBHOOK_ID=$(extract_id)
+    [[ -n "$WEBHOOK_ID" ]] && CLEANUP_WEBHOOKS+=("$WEBHOOK_ID")
   fi
 
   if [[ -n "$WEBHOOK_ID" ]]; then
@@ -229,16 +491,15 @@ if should_run "webhooks"; then
         --name "CLI Test Webhook Updated" \
         --url "https://httpbin.org/post" \
         --events "token.created" \
-        $JSON_FLAG || true
+        $JSON_FLAG
 
     run_test "Ping webhooks" \
-      $BT webhooks ping $JSON_FLAG || true
+      $BT webhooks ping $JSON_FLAG
 
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete webhook ($WEBHOOK_ID)" \
-        $BT webhooks delete "$WEBHOOK_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete webhook (--skip-destructive)"
+    run_test "Delete webhook ($WEBHOOK_ID)" \
+      $BT webhooks delete "$WEBHOOK_ID" --force $JSON_FLAG
+    if $LAST_TEST_PASSED; then
+      CLEANUP_WEBHOOKS=("${CLEANUP_WEBHOOKS[@]/$WEBHOOK_ID/}")
     fi
   fi
 fi
@@ -252,17 +513,20 @@ if should_run "keys"; then
     $BT keys $JSON_FLAG
 
   KEY_ID=""
-  if run_test "Create client key" \
-    $BT keys create $JSON_FLAG; then
-    KEY_ID=$(extract_field "keyId") || KEY_ID=$(extract_field "key_id") || KEY_ID=$(extract_id)
+  run_test "Create client key" \
+    $BT keys create $JSON_FLAG
+  if $LAST_TEST_PASSED; then
+    KEY_ID=$(extract_field "keyId")
+    [[ -z "$KEY_ID" ]] && KEY_ID=$(extract_field "key_id")
+    [[ -z "$KEY_ID" ]] && KEY_ID=$(extract_id)
+    [[ -n "$KEY_ID" ]] && CLEANUP_KEYS+=("$KEY_ID")
   fi
 
   if [[ -n "$KEY_ID" ]]; then
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete client key ($KEY_ID)" \
-        $BT keys delete "$KEY_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete client key (--skip-destructive)"
+    run_test "Delete client key ($KEY_ID)" \
+      $BT keys delete "$KEY_ID" --force $JSON_FLAG
+    if $LAST_TEST_PASSED; then
+      CLEANUP_KEYS=("${CLEANUP_KEYS[@]/$KEY_ID/}")
     fi
   fi
 fi
@@ -277,19 +541,21 @@ if should_run "tokens"; then
   section_header "Tokens"
 
   TOKEN_ID=""
-  if run_test "Create token" \
+  run_test "Create token" \
     $BT tokens create \
       --type token \
       --data '{"value": "cli-test-secret"}' \
-      $JSON_FLAG; then
+      $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     TOKEN_ID=$(extract_id)
+    [[ -n "$TOKEN_ID" ]] && CLEANUP_TOKENS+=("$TOKEN_ID")
   fi
 
   run_test "List tokens" \
     $BT tokens $JSON_FLAG
 
   run_test "List token types (reference)" \
-    $BT tokens types $JSON_FLAG || true
+    $BT tokens types $JSON_FLAG
 
   if [[ -n "$TOKEN_ID" ]]; then
     run_test "Get token ($TOKEN_ID)" \
@@ -298,16 +564,15 @@ if should_run "tokens"; then
     run_test "Update token ($TOKEN_ID)" \
       $BT tokens update "$TOKEN_ID" \
         --data '{"value": "cli-test-updated"}' \
-        $JSON_FLAG || true
+        $JSON_FLAG
 
     run_test "Search tokens" \
-      $BT tokens search --query "type:token" $JSON_FLAG || true
+      $BT tokens search --query "type:token" $JSON_FLAG
 
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete token ($TOKEN_ID)" \
-        $BT tokens delete "$TOKEN_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete token (--skip-destructive)"
+    run_test "Delete token ($TOKEN_ID)" \
+      $BT tokens delete "$TOKEN_ID" --force $JSON_FLAG
+    if $LAST_TEST_PASSED; then
+      CLEANUP_TOKENS=("${CLEANUP_TOKENS[@]/$TOKEN_ID/}")
     fi
   fi
 
@@ -327,23 +592,24 @@ if should_run "token-intents"; then
   section_header "Token Intents"
 
   INTENT_ID=""
-  if run_test "Create token intent" \
+  run_test "Create token intent" \
     $BT token-intents create \
       --type card \
       --data '{"number": "4242424242424242", "expiration_month": 12, "expiration_year": 2026, "cvc": "123"}' \
-      $JSON_FLAG; then
+      $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     INTENT_ID=$(extract_id)
+    [[ -n "$INTENT_ID" ]] && CLEANUP_TOKEN_INTENTS+=("$INTENT_ID")
   fi
 
   if [[ -n "$INTENT_ID" ]]; then
     run_test "Get token intent ($INTENT_ID)" \
       $BT token-intents get "$INTENT_ID" $JSON_FLAG
 
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete token intent ($INTENT_ID)" \
-        $BT token-intents delete "$INTENT_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete token intent (--skip-destructive)"
+    run_test "Delete token intent ($INTENT_ID)" \
+      $BT token-intents delete "$INTENT_ID" --force $JSON_FLAG
+    if $LAST_TEST_PASSED; then
+      CLEANUP_TOKEN_INTENTS=("${CLEANUP_TOKEN_INTENTS[@]/$INTENT_ID/}")
     fi
   fi
 fi
@@ -354,13 +620,16 @@ if should_run "documents"; then
   section_header "Documents"
 
   # Create a temp file to upload
-  TEMP_DOC=$(mktemp /tmp/bt-cli-test-XXXXXX.txt)
+  TEMP_DOC=$(mktemp /tmp/bt-cli-test-XXXXXX)
   echo "CLI test document content" > "$TEMP_DOC"
+  CLEANUP_TEMP_FILES+=("$TEMP_DOC" "/tmp/bt-cli-test-download.txt")
 
   DOC_ID=""
-  if run_test "Upload document" \
-    $BT documents upload --file "$TEMP_DOC" $JSON_FLAG; then
+  run_test "Upload document" \
+    $BT documents upload --file "$TEMP_DOC" $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     DOC_ID=$(extract_id)
+    [[ -n "$DOC_ID" ]] && CLEANUP_DOCUMENTS+=("$DOC_ID")
   fi
 
   if [[ -n "$DOC_ID" ]]; then
@@ -368,17 +637,14 @@ if should_run "documents"; then
       $BT documents get "$DOC_ID" $JSON_FLAG
 
     run_test "Download document ($DOC_ID)" \
-      $BT documents download "$DOC_ID" --output /tmp/bt-cli-test-download.txt $JSON_FLAG || true
+      $BT documents download "$DOC_ID" --output /tmp/bt-cli-test-download.txt $JSON_FLAG
 
-    if ! $SKIP_DESTRUCTIVE; then
-      run_test "Delete document ($DOC_ID)" \
-        $BT documents delete "$DOC_ID" --force $JSON_FLAG
-    else
-      skip_test "Delete document (--skip-destructive)"
+    run_test "Delete document ($DOC_ID)" \
+      $BT documents delete "$DOC_ID" --force $JSON_FLAG
+    if $LAST_TEST_PASSED; then
+      CLEANUP_DOCUMENTS=("${CLEANUP_DOCUMENTS[@]/$DOC_ID/}")
     fi
   fi
-
-  rm -f "$TEMP_DOC" /tmp/bt-cli-test-download.txt
 fi
 
 # ─── Invoke Reactors ───────────────────────────────────────────────────────────
@@ -386,32 +652,41 @@ fi
 if should_run "reactors-invoke"; then
   section_header "Invoke Reactors"
 
-  echo -e "  ${YELLOW}Note: Reactor invoke tests require an existing reactor ID.${NC}"
-  echo -e "  ${YELLOW}Set REACTOR_ID env var to test. Skipping if not set.${NC}"
+  # Create a simple reactor for testing
+  REACTOR_CODE=$(mktemp /tmp/bt-cli-test-reactor-XXXXXX.js)
+  CLEANUP_TEMP_FILES+=("$REACTOR_CODE")
+  cat > "$REACTOR_CODE" << 'JSEOF'
+module.exports = async function (req) {
+  return { raw: { tokenId: req.args.tokenId, echo: true } };
+};
+JSEOF
 
-  if [[ -n "${REACTOR_ID:-}" ]]; then
+  REACTOR_ID=""
+  run_test "Create test reactor" \
+    $BT reactors create \
+      --name "CLI Test Reactor $(date +%s)" \
+      --code "$REACTOR_CODE" \
+      --image node-bt \
+      --async
+  if $LAST_TEST_PASSED; then
+    REACTOR_ID=$(extract_id)
+    [[ -n "$REACTOR_ID" ]] && CLEANUP_REACTORS+=("$REACTOR_ID")
+  fi
+
+  if [[ -n "$REACTOR_ID" ]]; then
+    # Wait for reactor to be ready
+    sleep 5
+
     run_test "Invoke reactor (sync)" \
       $BT reactors invoke "$REACTOR_ID" \
-        --data '{"args": {"test": true}}' \
-        $JSON_FLAG || true
+        --data '{"args": {"tokenId": "tok-test-123"}}' \
+        $JSON_FLAG
 
-    ASYNC_REQUEST_ID=""
-    if run_test "Invoke reactor (async)" \
-      $BT reactors invoke-async "$REACTOR_ID" \
-        --data '{"args": {"test": true}}' \
-        $JSON_FLAG; then
-      ASYNC_REQUEST_ID=$(extract_field "asyncReactorRequestId")
+    run_test "Delete test reactor ($REACTOR_ID)" \
+      $BT reactors delete "$REACTOR_ID" --yes
+    if $LAST_TEST_PASSED; then
+      CLEANUP_REACTORS=("${CLEANUP_REACTORS[@]/$REACTOR_ID/}")
     fi
-
-    if [[ -n "$ASYNC_REQUEST_ID" ]]; then
-      sleep 2
-      run_test "Get async reactor result" \
-        $BT reactors get-result "$REACTOR_ID" "$ASYNC_REQUEST_ID" $JSON_FLAG || true
-    fi
-  else
-    skip_test "Invoke reactor (sync) — REACTOR_ID not set"
-    skip_test "Invoke reactor (async) — REACTOR_ID not set"
-    skip_test "Get async result — REACTOR_ID not set"
   fi
 fi
 
@@ -440,8 +715,9 @@ if should_run "account-updater"; then
     $BT account-updater jobs $JSON_FLAG || true
 
   JOB_ID=""
-  if run_test "Create account updater job" \
-    $BT account-updater jobs create $JSON_FLAG; then
+  run_test "Create account updater job" \
+    $BT account-updater jobs create $JSON_FLAG
+  if $LAST_TEST_PASSED; then
     JOB_ID=$(extract_id)
   fi
 
@@ -466,16 +742,18 @@ fi
 # ─── Network Tokens ────────────────────────────────────────────────────────────
 
 if should_run "network-tokens"; then
-  section_header "Network Tokens"
+  section_header "[Beta] Network Tokens"
 
   echo -e "  ${YELLOW}Note: Network token operations require valid card tokens.${NC}"
   echo -e "  ${YELLOW}Set NT_TOKEN_ID env var to test creation. Skipping if not set.${NC}"
 
   if [[ -n "${NT_TOKEN_ID:-}" ]]; then
     NT_ID=""
-    if run_test "Create network token" \
-      $BT network-tokens create --token-id "$NT_TOKEN_ID" $JSON_FLAG; then
+    run_test "Create network token" \
+      $BT network-tokens create --token-id "$NT_TOKEN_ID" $JSON_FLAG
+    if $LAST_TEST_PASSED; then
       NT_ID=$(extract_id)
+      [[ -n "$NT_ID" ]] && CLEANUP_NETWORK_TOKENS+=("$NT_ID")
     fi
 
     if [[ -n "$NT_ID" ]]; then
@@ -483,19 +761,18 @@ if should_run "network-tokens"; then
         $BT network-tokens get "$NT_ID" $JSON_FLAG
 
       run_test "Generate cryptogram ($NT_ID)" \
-        $BT network-tokens cryptogram "$NT_ID" $JSON_FLAG || true
+        $BT network-tokens cryptogram "$NT_ID" $JSON_FLAG
 
       run_test "Suspend network token ($NT_ID)" \
-        $BT network-tokens suspend "$NT_ID" $JSON_FLAG || true
+        $BT network-tokens suspend "$NT_ID" $JSON_FLAG
 
       run_test "Resume network token ($NT_ID)" \
-        $BT network-tokens resume "$NT_ID" $JSON_FLAG || true
+        $BT network-tokens resume "$NT_ID" $JSON_FLAG
 
-      if ! $SKIP_DESTRUCTIVE; then
-        run_test "Delete network token ($NT_ID)" \
-          $BT network-tokens delete "$NT_ID" --force $JSON_FLAG
-      else
-        skip_test "Delete network token (--skip-destructive)"
+      run_test "Delete network token ($NT_ID)" \
+        $BT network-tokens delete "$NT_ID" --force $JSON_FLAG
+      if $LAST_TEST_PASSED; then
+        CLEANUP_NETWORK_TOKENS=("${CLEANUP_NETWORK_TOKENS[@]/$NT_ID/}")
       fi
     fi
   else
@@ -507,15 +784,16 @@ fi
 # ─── 3DS Sessions ──────────────────────────────────────────────────────────────
 
 if should_run "3ds"; then
-  section_header "3DS Sessions"
+  section_header "[Beta] 3DS Sessions"
 
   echo -e "  ${YELLOW}Note: 3DS requires a valid card token or token intent.${NC}"
   echo -e "  ${YELLOW}Set THREEDS_TOKEN_ID env var to test. Skipping if not set.${NC}"
 
   if [[ -n "${THREEDS_TOKEN_ID:-}" ]]; then
     SESSION_ID=""
-    if run_test "Create 3DS session" \
-      $BT 3ds sessions create --token-id "$THREEDS_TOKEN_ID" $JSON_FLAG; then
+    run_test "Create 3DS session" \
+      $BT 3ds sessions create --token-id "$THREEDS_TOKEN_ID" $JSON_FLAG
+    if $LAST_TEST_PASSED; then
       SESSION_ID=$(extract_id)
     fi
 
@@ -540,7 +818,7 @@ fi
 # ─── Enrichments ────────────────────────────────────────────────────────────────
 
 if should_run "enrichments"; then
-  section_header "Enrichments"
+  section_header "[Beta] Enrichments"
 
   echo -e "  ${YELLOW}Note: Bank account verification requires a valid bank token.${NC}"
   echo -e "  ${YELLOW}Set BANK_TOKEN_ID env var to test. Skipping if not set.${NC}"
@@ -559,7 +837,7 @@ fi
 # ─── Apple Pay ──────────────────────────────────────────────────────────────────
 
 if should_run "apple-pay"; then
-  section_header "Apple Pay"
+  section_header "[Beta] Apple Pay"
 
   run_test "List Apple Pay domains" \
     $BT apple-pay domains $JSON_FLAG || true
@@ -578,7 +856,7 @@ fi
 # ─── Google Pay ─────────────────────────────────────────────────────────────────
 
 if should_run "google-pay"; then
-  section_header "Google Pay"
+  section_header "[Beta] Google Pay"
 
   echo -e "  ${YELLOW}Note: Google Pay operations require real payment data and merchant setup.${NC}"
   echo -e "  ${YELLOW}Most operations will fail without proper configuration.${NC}"
@@ -607,20 +885,20 @@ if should_run "connections"; then
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# EXISTING ENDPOINTS (Smoke Tests)
+# MANAGEMENT LISTING (Smoke Tests)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 if should_run "existing"; then
-  section_header "Existing Endpoints (Smoke Tests)"
+  section_header "Management Listings"
 
   run_test "List applications" \
-    $BT applications --page 1
+    $BT applications $JSON_FLAG
 
   run_test "List reactors" \
-    $BT reactors --page 1
+    $BT reactors $JSON_FLAG
 
   run_test "List proxies" \
-    $BT proxies --page 1
+    $BT proxies $JSON_FLAG
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/test-endpoints.sh
+++ b/scripts/test-endpoints.sh
@@ -1,0 +1,646 @@
+#!/usr/bin/env bash
+#
+# End-to-end CLI test script for all Basis Theory CLI endpoints.
+# Exercises every command with real API calls.
+#
+# Usage:
+#   export BT_MANAGEMENT_KEY="your_management_key"
+#   export BT_API_KEY="your_private_api_key"
+#   ./scripts/test-endpoints.sh
+#
+# Options:
+#   --skip-destructive   Skip delete/destroy operations
+#   --json               Pass --json to all commands
+#   --verbose            Print full command output
+#   --section SECTION    Run only a specific section (tenants, logs, webhooks, keys, tokens, etc.)
+#
+
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+SKIP_DESTRUCTIVE=false
+JSON_FLAG=""
+VERBOSE=false
+SECTION=""
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+BT="./bin/run"
+
+# ─── Parse Arguments ────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --skip-destructive) SKIP_DESTRUCTIVE=true; shift ;;
+    --json) JSON_FLAG="--json"; shift ;;
+    --verbose) VERBOSE=true; shift ;;
+    --section) SECTION="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ─── Validation ─────────────────────────────────────────────────────────────────
+
+if [[ -z "${BT_MANAGEMENT_KEY:-}" ]]; then
+  echo -e "${RED}Error: BT_MANAGEMENT_KEY environment variable is required${NC}"
+  echo "Export it before running: export BT_MANAGEMENT_KEY=your_key"
+  exit 1
+fi
+
+if [[ -z "${BT_API_KEY:-}" ]]; then
+  echo -e "${YELLOW}Warning: BT_API_KEY not set. Tokenization commands will use BT_MANAGEMENT_KEY.${NC}"
+fi
+
+# ─── Helpers ────────────────────────────────────────────────────────────────────
+
+run_test() {
+  local description="$1"
+  shift
+  local cmd=("$@")
+
+  printf "  %-60s " "$description"
+
+  local output
+  if output=$("${cmd[@]}" 2>&1); then
+    echo -e "${GREEN}PASS${NC}"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    if $VERBOSE; then
+      echo "$output" | sed 's/^/    │ /'
+    fi
+    # Store last output for chaining
+    LAST_OUTPUT="$output"
+    return 0
+  else
+    echo -e "${RED}FAIL${NC}"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "$output" | sed 's/^/    │ /' | head -5
+    LAST_OUTPUT=""
+    return 1
+  fi
+}
+
+skip_test() {
+  local description="$1"
+  printf "  %-60s " "$description"
+  echo -e "${YELLOW}SKIP${NC}"
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+}
+
+section_header() {
+  echo ""
+  echo -e "${BLUE}━━━ $1 ━━━${NC}"
+}
+
+should_run() {
+  [[ -z "$SECTION" || "$SECTION" == "$1" ]]
+}
+
+extract_id() {
+  # Extract an ID from JSON output (first "id" field found)
+  echo "$LAST_OUTPUT" | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"'
+}
+
+extract_field() {
+  local field="$1"
+  echo "$LAST_OUTPUT" | grep -o "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 | grep -o '"[^"]*"$' | tr -d '"'
+}
+
+# ─── Build ──────────────────────────────────────────────────────────────────────
+
+section_header "Building CLI"
+run_test "yarn build" yarn build
+
+echo ""
+echo -e "${BLUE}Starting endpoint tests...${NC}"
+echo -e "  Management Key: ${BT_MANAGEMENT_KEY:0:10}..."
+if [[ -n "${BT_API_KEY:-}" ]]; then
+  echo -e "  API Key: ${BT_API_KEY:0:10}..."
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MANAGEMENT ENDPOINTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Tenants ────────────────────────────────────────────────────────────────────
+
+if should_run "tenants"; then
+  section_header "Tenants"
+
+  run_test "Get current tenant" \
+    $BT tenants get $JSON_FLAG
+
+  run_test "Get tenant usage report" \
+    $BT tenants usage $JSON_FLAG
+
+  run_test "Update tenant name" \
+    $BT tenants update --name "CLI Test Tenant" $JSON_FLAG || true
+
+  # Members
+  section_header "Tenant Members"
+
+  run_test "List tenant members" \
+    $BT tenants members $JSON_FLAG
+
+  run_test "List tenant members (page 1, size 5)" \
+    $BT tenants members --page 1 --size 5 $JSON_FLAG
+
+  # Invitations
+  section_header "Tenant Invitations"
+
+  run_test "List tenant invitations" \
+    $BT tenants invitations $JSON_FLAG
+
+  INVITATION_ID=""
+  if run_test "Create tenant invitation" \
+    $BT tenants invitations create --email "cli-test-$(date +%s)@example.com" --role ADMIN $JSON_FLAG; then
+    INVITATION_ID=$(extract_id)
+  fi
+
+  if [[ -n "$INVITATION_ID" ]]; then
+    run_test "Resend invitation ($INVITATION_ID)" \
+      $BT tenants invitations resend "$INVITATION_ID" $JSON_FLAG || true
+
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete invitation ($INVITATION_ID)" \
+        $BT tenants invitations delete "$INVITATION_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete invitation (--skip-destructive)"
+    fi
+  fi
+
+  # Merchants
+  section_header "Tenant Merchants"
+
+  run_test "List tenant merchants" \
+    $BT tenants merchants $JSON_FLAG || true
+fi
+
+# ─── Logs ───────────────────────────────────────────────────────────────────────
+
+if should_run "logs"; then
+  section_header "Logs"
+
+  run_test "List audit logs" \
+    $BT logs $JSON_FLAG
+
+  run_test "List logs (filtered by entity type)" \
+    $BT logs --entity-type application $JSON_FLAG || true
+
+  run_test "List log entity types" \
+    $BT logs entity-types $JSON_FLAG
+fi
+
+# ─── Webhooks ───────────────────────────────────────────────────────────────────
+
+if should_run "webhooks"; then
+  section_header "Webhooks"
+
+  run_test "List webhooks" \
+    $BT webhooks $JSON_FLAG
+
+  run_test "List webhook event types" \
+    $BT webhooks events $JSON_FLAG
+
+  WEBHOOK_ID=""
+  if run_test "Create webhook" \
+    $BT webhooks create \
+      --name "CLI Test Webhook $(date +%s)" \
+      --url "https://httpbin.org/post" \
+      --events "token.created" \
+      --events "token.deleted" \
+      $JSON_FLAG; then
+    WEBHOOK_ID=$(extract_id)
+  fi
+
+  if [[ -n "$WEBHOOK_ID" ]]; then
+    run_test "Get webhook ($WEBHOOK_ID)" \
+      $BT webhooks get "$WEBHOOK_ID" $JSON_FLAG
+
+    run_test "Update webhook ($WEBHOOK_ID)" \
+      $BT webhooks update "$WEBHOOK_ID" \
+        --name "CLI Test Webhook Updated" \
+        --url "https://httpbin.org/post" \
+        --events "token.created" \
+        $JSON_FLAG || true
+
+    run_test "Ping webhooks" \
+      $BT webhooks ping $JSON_FLAG || true
+
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete webhook ($WEBHOOK_ID)" \
+        $BT webhooks delete "$WEBHOOK_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete webhook (--skip-destructive)"
+    fi
+  fi
+fi
+
+# ─── Client Keys ────────────────────────────────────────────────────────────────
+
+if should_run "keys"; then
+  section_header "Client Keys"
+
+  run_test "List client keys" \
+    $BT keys $JSON_FLAG
+
+  KEY_ID=""
+  if run_test "Create client key" \
+    $BT keys create $JSON_FLAG; then
+    KEY_ID=$(extract_field "keyId") || KEY_ID=$(extract_field "key_id") || KEY_ID=$(extract_id)
+  fi
+
+  if [[ -n "$KEY_ID" ]]; then
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete client key ($KEY_ID)" \
+        $BT keys delete "$KEY_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete client key (--skip-destructive)"
+    fi
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TOKENIZATION ENDPOINTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Tokens ─────────────────────────────────────────────────────────────────────
+
+if should_run "tokens"; then
+  section_header "Tokens"
+
+  TOKEN_ID=""
+  if run_test "Create token" \
+    $BT tokens create \
+      --type token \
+      --data '{"value": "cli-test-secret"}' \
+      $JSON_FLAG; then
+    TOKEN_ID=$(extract_id)
+  fi
+
+  run_test "List tokens" \
+    $BT tokens $JSON_FLAG
+
+  run_test "List token types (reference)" \
+    $BT tokens types $JSON_FLAG || true
+
+  if [[ -n "$TOKEN_ID" ]]; then
+    run_test "Get token ($TOKEN_ID)" \
+      $BT tokens get "$TOKEN_ID" $JSON_FLAG
+
+    run_test "Update token ($TOKEN_ID)" \
+      $BT tokens update "$TOKEN_ID" \
+        --data '{"value": "cli-test-updated"}' \
+        $JSON_FLAG || true
+
+    run_test "Search tokens" \
+      $BT tokens search --query "type:token" $JSON_FLAG || true
+
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete token ($TOKEN_ID)" \
+        $BT tokens delete "$TOKEN_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete token (--skip-destructive)"
+    fi
+  fi
+
+  # Tokenize / Detokenize
+  section_header "Tokenize / Detokenize"
+
+  run_test "Tokenize (inline JSON)" \
+    $BT tokenize --data '{"first_name": "John", "last_name": "Doe"}' $JSON_FLAG || true
+
+  run_test "Detokenize" \
+    $BT detokenize --data '{"value": "not-a-real-token"}' $JSON_FLAG || true
+fi
+
+# ─── Token Intents ──────────────────────────────────────────────────────────────
+
+if should_run "token-intents"; then
+  section_header "Token Intents"
+
+  INTENT_ID=""
+  if run_test "Create token intent" \
+    $BT token-intents create \
+      --type card \
+      --data '{"number": "4242424242424242", "expiration_month": 12, "expiration_year": 2026, "cvc": "123"}' \
+      $JSON_FLAG; then
+    INTENT_ID=$(extract_id)
+  fi
+
+  if [[ -n "$INTENT_ID" ]]; then
+    run_test "Get token intent ($INTENT_ID)" \
+      $BT token-intents get "$INTENT_ID" $JSON_FLAG
+
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete token intent ($INTENT_ID)" \
+        $BT token-intents delete "$INTENT_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete token intent (--skip-destructive)"
+    fi
+  fi
+fi
+
+# ─── Documents ──────────────────────────────────────────────────────────────────
+
+if should_run "documents"; then
+  section_header "Documents"
+
+  # Create a temp file to upload
+  TEMP_DOC=$(mktemp /tmp/bt-cli-test-XXXXXX.txt)
+  echo "CLI test document content" > "$TEMP_DOC"
+
+  DOC_ID=""
+  if run_test "Upload document" \
+    $BT documents upload --file "$TEMP_DOC" $JSON_FLAG; then
+    DOC_ID=$(extract_id)
+  fi
+
+  if [[ -n "$DOC_ID" ]]; then
+    run_test "Get document metadata ($DOC_ID)" \
+      $BT documents get "$DOC_ID" $JSON_FLAG
+
+    run_test "Download document ($DOC_ID)" \
+      $BT documents download "$DOC_ID" --output /tmp/bt-cli-test-download.txt $JSON_FLAG || true
+
+    if ! $SKIP_DESTRUCTIVE; then
+      run_test "Delete document ($DOC_ID)" \
+        $BT documents delete "$DOC_ID" --force $JSON_FLAG
+    else
+      skip_test "Delete document (--skip-destructive)"
+    fi
+  fi
+
+  rm -f "$TEMP_DOC" /tmp/bt-cli-test-download.txt
+fi
+
+# ─── Invoke Reactors ───────────────────────────────────────────────────────────
+
+if should_run "reactors-invoke"; then
+  section_header "Invoke Reactors"
+
+  echo -e "  ${YELLOW}Note: Reactor invoke tests require an existing reactor ID.${NC}"
+  echo -e "  ${YELLOW}Set REACTOR_ID env var to test. Skipping if not set.${NC}"
+
+  if [[ -n "${REACTOR_ID:-}" ]]; then
+    run_test "Invoke reactor (sync)" \
+      $BT reactors invoke "$REACTOR_ID" \
+        --data '{"args": {"test": true}}' \
+        $JSON_FLAG || true
+
+    ASYNC_REQUEST_ID=""
+    if run_test "Invoke reactor (async)" \
+      $BT reactors invoke-async "$REACTOR_ID" \
+        --data '{"args": {"test": true}}' \
+        $JSON_FLAG; then
+      ASYNC_REQUEST_ID=$(extract_field "asyncReactorRequestId")
+    fi
+
+    if [[ -n "$ASYNC_REQUEST_ID" ]]; then
+      sleep 2
+      run_test "Get async reactor result" \
+        $BT reactors get-result "$REACTOR_ID" "$ASYNC_REQUEST_ID" $JSON_FLAG || true
+    fi
+  else
+    skip_test "Invoke reactor (sync) — REACTOR_ID not set"
+    skip_test "Invoke reactor (async) — REACTOR_ID not set"
+    skip_test "Get async result — REACTOR_ID not set"
+  fi
+fi
+
+# ─── Invoke Proxies ────────────────────────────────────────────────────────────
+
+if should_run "proxies-invoke"; then
+  section_header "Invoke Proxies"
+
+  run_test "Invoke ephemeral proxy" \
+    $BT proxies invoke \
+      --method GET \
+      --proxy-url "https://httpbin.org/get" \
+      $JSON_FLAG || true
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CREDENTIAL MANAGEMENT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# ─── Account Updater ────────────────────────────────────────────────────────────
+
+if should_run "account-updater"; then
+  section_header "Account Updater"
+
+  run_test "List account updater jobs" \
+    $BT account-updater jobs $JSON_FLAG || true
+
+  JOB_ID=""
+  if run_test "Create account updater job" \
+    $BT account-updater jobs create $JSON_FLAG; then
+    JOB_ID=$(extract_id)
+  fi
+
+  if [[ -n "$JOB_ID" ]]; then
+    run_test "Get account updater job ($JOB_ID)" \
+      $BT account-updater jobs get "$JOB_ID" $JSON_FLAG || true
+  fi
+
+  echo -e "  ${YELLOW}Note: Real-time account updater requires a valid card token.${NC}"
+  echo -e "  ${YELLOW}Set AU_TOKEN_ID env var to test. Skipping if not set.${NC}"
+
+  if [[ -n "${AU_TOKEN_ID:-}" ]]; then
+    run_test "Real-time account update" \
+      $BT account-updater real-time \
+        --token-id "$AU_TOKEN_ID" \
+        $JSON_FLAG || true
+  else
+    skip_test "Real-time account update — AU_TOKEN_ID not set"
+  fi
+fi
+
+# ─── Network Tokens ────────────────────────────────────────────────────────────
+
+if should_run "network-tokens"; then
+  section_header "Network Tokens"
+
+  echo -e "  ${YELLOW}Note: Network token operations require valid card tokens.${NC}"
+  echo -e "  ${YELLOW}Set NT_TOKEN_ID env var to test creation. Skipping if not set.${NC}"
+
+  if [[ -n "${NT_TOKEN_ID:-}" ]]; then
+    NT_ID=""
+    if run_test "Create network token" \
+      $BT network-tokens create --token-id "$NT_TOKEN_ID" $JSON_FLAG; then
+      NT_ID=$(extract_id)
+    fi
+
+    if [[ -n "$NT_ID" ]]; then
+      run_test "Get network token ($NT_ID)" \
+        $BT network-tokens get "$NT_ID" $JSON_FLAG
+
+      run_test "Generate cryptogram ($NT_ID)" \
+        $BT network-tokens cryptogram "$NT_ID" $JSON_FLAG || true
+
+      run_test "Suspend network token ($NT_ID)" \
+        $BT network-tokens suspend "$NT_ID" $JSON_FLAG || true
+
+      run_test "Resume network token ($NT_ID)" \
+        $BT network-tokens resume "$NT_ID" $JSON_FLAG || true
+
+      if ! $SKIP_DESTRUCTIVE; then
+        run_test "Delete network token ($NT_ID)" \
+          $BT network-tokens delete "$NT_ID" --force $JSON_FLAG
+      else
+        skip_test "Delete network token (--skip-destructive)"
+      fi
+    fi
+  else
+    skip_test "Create network token — NT_TOKEN_ID not set"
+    skip_test "Get/cryptogram/suspend/resume/delete — skipped"
+  fi
+fi
+
+# ─── 3DS Sessions ──────────────────────────────────────────────────────────────
+
+if should_run "3ds"; then
+  section_header "3DS Sessions"
+
+  echo -e "  ${YELLOW}Note: 3DS requires a valid card token or token intent.${NC}"
+  echo -e "  ${YELLOW}Set THREEDS_TOKEN_ID env var to test. Skipping if not set.${NC}"
+
+  if [[ -n "${THREEDS_TOKEN_ID:-}" ]]; then
+    SESSION_ID=""
+    if run_test "Create 3DS session" \
+      $BT 3ds sessions create --token-id "$THREEDS_TOKEN_ID" $JSON_FLAG; then
+      SESSION_ID=$(extract_id)
+    fi
+
+    if [[ -n "$SESSION_ID" ]]; then
+      run_test "Get 3DS session ($SESSION_ID)" \
+        $BT 3ds sessions get "$SESSION_ID" $JSON_FLAG
+
+      run_test "Authenticate 3DS session ($SESSION_ID)" \
+        $BT 3ds sessions authenticate "$SESSION_ID" \
+          --data '{"authentication_category": "payment", "authentication_type": "payment-transaction"}' \
+          $JSON_FLAG || true
+
+      run_test "Get challenge result ($SESSION_ID)" \
+        $BT 3ds sessions challenge-result "$SESSION_ID" $JSON_FLAG || true
+    fi
+  else
+    skip_test "Create 3DS session — THREEDS_TOKEN_ID not set"
+    skip_test "Get/authenticate/challenge-result — skipped"
+  fi
+fi
+
+# ─── Enrichments ────────────────────────────────────────────────────────────────
+
+if should_run "enrichments"; then
+  section_header "Enrichments"
+
+  echo -e "  ${YELLOW}Note: Bank account verification requires a valid bank token.${NC}"
+  echo -e "  ${YELLOW}Set BANK_TOKEN_ID env var to test. Skipping if not set.${NC}"
+
+  if [[ -n "${BANK_TOKEN_ID:-}" ]]; then
+    run_test "Verify bank account" \
+      $BT enrichments bank-account-verify \
+        --token-id "$BANK_TOKEN_ID" \
+        --country-code US \
+        $JSON_FLAG || true
+  else
+    skip_test "Verify bank account — BANK_TOKEN_ID not set"
+  fi
+fi
+
+# ─── Apple Pay ──────────────────────────────────────────────────────────────────
+
+if should_run "apple-pay"; then
+  section_header "Apple Pay"
+
+  run_test "List Apple Pay domains" \
+    $BT apple-pay domains $JSON_FLAG || true
+
+  echo -e "  ${YELLOW}Note: Apple Pay tokenization requires real payment data.${NC}"
+  echo -e "  ${YELLOW}Domain/merchant/certificate operations require apple-pay:manage permission.${NC}"
+
+  # Domain registration (safe to test)
+  run_test "Register Apple Pay domain" \
+    $BT apple-pay domains register --domain "cli-test.example.com" $JSON_FLAG || true
+
+  run_test "Deregister Apple Pay domain" \
+    $BT apple-pay domains deregister --domain "cli-test.example.com" $JSON_FLAG || true
+fi
+
+# ─── Google Pay ─────────────────────────────────────────────────────────────────
+
+if should_run "google-pay"; then
+  section_header "Google Pay"
+
+  echo -e "  ${YELLOW}Note: Google Pay operations require real payment data and merchant setup.${NC}"
+  echo -e "  ${YELLOW}Most operations will fail without proper configuration.${NC}"
+
+  # These will likely fail without proper setup, but tests the CLI wiring
+  run_test "Create Google Pay merchant" \
+    $BT google-pay merchants create --merchant-identifier "cli-test-merchant" $JSON_FLAG || true
+fi
+
+# ─── Connections ────────────────────────────────────────────────────────────────
+
+if should_run "connections"; then
+  section_header "Connections (Stripe Forward)"
+
+  echo -e "  ${YELLOW}Note: Stripe Forward requires a configured Stripe connection.${NC}"
+  echo -e "  ${YELLOW}Skipping unless STRIPE_FORWARD_TEST=true is set.${NC}"
+
+  if [[ "${STRIPE_FORWARD_TEST:-}" == "true" ]]; then
+    run_test "Stripe Forward tokenize" \
+      $BT connections stripe-forward tokenize \
+        --data '{"number": "4242424242424242", "exp_month": "12", "exp_year": "2026", "cvc": "123"}' \
+        $JSON_FLAG || true
+  else
+    skip_test "Stripe Forward tokenize — STRIPE_FORWARD_TEST not set"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# EXISTING ENDPOINTS (Smoke Tests)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if should_run "existing"; then
+  section_header "Existing Endpoints (Smoke Tests)"
+
+  run_test "List applications" \
+    $BT applications --page 1
+
+  run_test "List reactors" \
+    $BT reactors --page 1
+
+  run_test "List proxies" \
+    $BT proxies --page 1
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Summary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BLUE}━━━ Results ━━━${NC}"
+echo ""
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo -e "  ${GREEN}Passed:  $PASS_COUNT${NC}"
+echo -e "  ${RED}Failed:  $FAIL_COUNT${NC}"
+echo -e "  ${YELLOW}Skipped: $SKIP_COUNT${NC}"
+echo -e "  Total:   $TOTAL"
+echo ""
+
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo -e "${RED}Some tests failed.${NC}"
+  exit 1
+else
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
+fi

--- a/src/api-command.ts
+++ b/src/api-command.ts
@@ -13,19 +13,25 @@ const formatApiError = (
   body: BasisTheory.ValidationProblemDetails | BasisTheory.ProblemDetails
 ): string => {
   const parts: string[] = [];
+  // SDK error bodies may use PascalCase or camelCase keys
+  const raw = body as Record<string, unknown>;
+  const title = body.title || (raw.Title as string);
+  const status = body.status || (raw.Status as number);
+  const detail = body.detail || (raw.Detail as string);
+  const errors = 'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
 
-  if (body.title) {
-    const status = body.status ? ` [${body.status}]` : '';
+  if (title) {
+    const statusStr = status ? ` [${status}]` : '';
 
-    parts.push(`${body.title}${status}`);
+    parts.push(`${title}${statusStr}`);
   }
 
-  if (body.detail) {
-    parts.push(`Detail: ${body.detail}`);
+  if (detail) {
+    parts.push(`Detail: ${detail}`);
   }
 
-  if ('errors' in body && body.errors) {
-    for (const [field, messages] of Object.entries(body.errors)) {
+  if (errors) {
+    for (const [field, messages] of Object.entries(errors)) {
       if (Array.isArray(messages)) {
         for (const message of messages) {
           parts.push(`  - ${field}: ${message}`);

--- a/src/api-command.ts
+++ b/src/api-command.ts
@@ -18,7 +18,8 @@ const formatApiError = (
   const title = body.title || (raw.Title as string);
   const status = body.status || (raw.Status as number);
   const detail = body.detail || (raw.Detail as string);
-  const errors = 'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
+  const errors =
+    'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
 
   if (title) {
     const statusStr = status ? ` [${status}]` : '';

--- a/src/api-command.ts
+++ b/src/api-command.ts
@@ -8,6 +8,7 @@ import type {
   Input,
   ParserOutput,
 } from '@oclif/core/lib/interfaces/parser';
+import { loadConfig } from './config';
 
 const formatApiError = (
   body: BasisTheory.ValidationProblemDetails | BasisTheory.ProblemDetails
@@ -80,13 +81,15 @@ export abstract class ApiCommand extends Command {
     }
   > {
     const { flags, ...parsed } = await super.parse(options, argv);
+    const config = loadConfig();
     const {
       'api-key': apiKey,
       'management-key': managementKey,
       'api-base-url': apiBaseUrl,
     } = flags;
 
-    const key = apiKey || managementKey;
+    const key =
+      apiKey || managementKey || config.apiKey || config.managementApiKey;
 
     if (!key) {
       this.error(
@@ -94,9 +97,11 @@ export abstract class ApiCommand extends Command {
       );
     }
 
+    const effectiveBaseUrl = apiBaseUrl || config.apiBaseUrl;
+
     const bt = new BasisTheoryClient({
       apiKey: key,
-      ...(apiBaseUrl ? { environment: apiBaseUrl } : {}),
+      ...(effectiveBaseUrl ? { environment: effectiveBaseUrl } : {}),
     });
 
     return {

--- a/src/api-command.ts
+++ b/src/api-command.ts
@@ -37,14 +37,17 @@ const formatApiError = (
   return parts.join('\n');
 };
 
-export abstract class BaseCommand extends Command {
+export abstract class ApiCommand extends Command {
   public static baseFlags = {
     'management-key': Flags.string({
       char: 'x',
       env: 'BT_MANAGEMENT_KEY',
-      description:
-        'management key used for connecting with the reactor / proxy',
-      required: true,
+      description: 'management key used for API authentication',
+    }),
+    'api-key': Flags.string({
+      char: 'k',
+      env: 'BT_API_KEY',
+      description: 'private API key used for API authentication',
     }),
     'api-base-url': Flags.string({
       env: 'BT_API_BASE_URL',
@@ -70,11 +73,22 @@ export abstract class BaseCommand extends Command {
     }
   > {
     const { flags, ...parsed } = await super.parse(options, argv);
-    const { 'management-key': managementKey, 'api-base-url': apiBaseUrl } =
-      flags;
+    const {
+      'api-key': apiKey,
+      'management-key': managementKey,
+      'api-base-url': apiBaseUrl,
+    } = flags;
+
+    const key = apiKey || managementKey;
+
+    if (!key) {
+      this.error(
+        'Either --api-key (BT_API_KEY) or --management-key (BT_MANAGEMENT_KEY) must be provided.'
+      );
+    }
 
     const bt = new BasisTheoryClient({
-      apiKey: managementKey,
+      apiKey: key,
       ...(apiBaseUrl ? { environment: apiBaseUrl } : {}),
     });
 

--- a/src/applications/management.ts
+++ b/src/applications/management.ts
@@ -1,10 +1,4 @@
 import type { BasisTheory, BasisTheoryClient } from '@basis-theory/node-sdk';
-import confirm from '@inquirer/confirm';
-import select from '@inquirer/select';
-import { ux } from '@oclif/core';
-import groupBy from 'lodash.groupby';
-import { TableRow } from '../types';
-import { selectOrNavigate, PaginatedList } from '../utils';
 
 const debug = require('debug')('applications:management');
 
@@ -20,78 +14,6 @@ const listPermissions = (
       permissions.sort((p1, p2) => (p1.type ?? '').localeCompare(p2.type ?? ''))
     );
 
-const listApplications = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<PaginatedList<BasisTheory.Application>> => {
-  const size = 5;
-
-  debug('Listing applications', `page: ${page}`, `size: ${size}`);
-
-  const applicationsPage = await bt.applications.list({
-    size,
-    page,
-  });
-
-  let data: TableRow<BasisTheory.Application>[] = [];
-
-  if (applicationsPage.data.length) {
-    const last = (page - 1) * size;
-
-    data = applicationsPage.data.map((application, index) => ({
-      '#': last + (index + 1),
-      ...application,
-    }));
-
-    ux.table(data, {
-      '#': {},
-      id: {},
-      name: {},
-      type: {},
-    });
-  } else {
-    ux.log('No applications found.');
-  }
-
-  return {
-    data,
-    page,
-    hasNextPage: applicationsPage.hasNextPage(),
-  };
-};
-
-const retrieveApplication = (
-  bt: BasisTheoryClient,
-  id: string
-): Promise<BasisTheory.Application> => {
-  debug(`Retrieving Application ${id}`);
-
-  return bt.applications.get(id);
-};
-
-const selectApplication = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<BasisTheory.Application | undefined> => {
-  const applications = await listApplications(bt, page);
-
-  if (!applications.data.length) {
-    return undefined;
-  }
-
-  const selection = await selectOrNavigate(applications, '#');
-
-  if (selection === 'previous') {
-    return selectApplication(bt, page - 1);
-  }
-
-  if (selection === 'next') {
-    return selectApplication(bt, page + 1);
-  }
-
-  return selection;
-};
-
 const createApplication = (
   bt: BasisTheoryClient,
   model: BasisTheory.CreateApplicationRequest
@@ -100,38 +22,27 @@ const createApplication = (
 
   return bt.applications.create(model);
 };
+
 const updateApplication = async (
   bt: BasisTheoryClient,
   id: string,
   model: Partial<BasisTheory.UpdateApplicationRequest>
 ): Promise<BasisTheory.Application> => {
-  const application = await retrieveApplication(bt, id);
+  const application = await bt.applications.get(id);
 
   debug(`Updating Application ${id}`, JSON.stringify(model, undefined, 2));
 
   return bt.applications.update(id, {
     name: model.name || application.name || '',
     permissions: model.permissions || application.permissions,
-    rules: model.permissions ? undefined : application.rules, // if permissions were passed, overwrite rules
+    rules: model.permissions ? undefined : application.rules,
   });
 };
 
 const deleteApplication = async (
   bt: BasisTheoryClient,
-  id: string,
-  force = false
+  id: string
 ): Promise<boolean> => {
-  if (!force) {
-    const proceed = await confirm({
-      message: `Are you sure you want to delete this Application (${id})?`,
-      default: false,
-    });
-
-    if (!proceed) {
-      return false;
-    }
-  }
-
   debug(`Deleting Application`, id);
 
   await bt.applications.delete(id);
@@ -157,45 +68,10 @@ const createApplicationFromTemplate = async (
   });
 };
 
-const promptTemplate = async (
-  bt: BasisTheoryClient
-): Promise<BasisTheory.ApplicationTemplate | undefined> => {
-  const useTemplate = await confirm({
-    message: 'Do you want to use an application template?',
-  });
-
-  if (!useTemplate) {
-    return undefined;
-  }
-
-  const templates = groupBy(
-    await bt.applicationTemplates.list(),
-    'templateType'
-  );
-
-  const type = await select({
-    message: 'Which template type do you want to use?',
-    choices: Object.keys(templates).map((t) => ({
-      value: t,
-    })),
-  });
-
-  return select({
-    message: 'Choose a template',
-    choices: templates[type].map((t) => ({
-      name: t.name,
-      value: t,
-      description: t.description,
-    })),
-  });
-};
-
 export {
   listPermissions,
   createApplication,
   updateApplication,
-  selectApplication,
   deleteApplication,
   createApplicationFromTemplate,
-  promptTemplate,
 };

--- a/src/base.ts
+++ b/src/base.ts
@@ -13,19 +13,25 @@ const formatApiError = (
   body: BasisTheory.ValidationProblemDetails | BasisTheory.ProblemDetails
 ): string => {
   const parts: string[] = [];
+  // SDK error bodies may use PascalCase or camelCase keys
+  const raw = body as Record<string, unknown>;
+  const title = body.title || (raw.Title as string);
+  const status = body.status || (raw.Status as number);
+  const detail = body.detail || (raw.Detail as string);
+  const errors = 'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
 
-  if (body.title) {
-    const status = body.status ? ` [${body.status}]` : '';
+  if (title) {
+    const statusStr = status ? ` [${status}]` : '';
 
-    parts.push(`${body.title}${status}`);
+    parts.push(`${title}${statusStr}`);
   }
 
-  if (body.detail) {
-    parts.push(`Detail: ${body.detail}`);
+  if (detail) {
+    parts.push(`Detail: ${detail}`);
   }
 
-  if ('errors' in body && body.errors) {
-    for (const [field, messages] of Object.entries(body.errors)) {
+  if (errors) {
+    for (const [field, messages] of Object.entries(errors)) {
       if (Array.isArray(messages)) {
         for (const message of messages) {
           parts.push(`  - ${field}: ${message}`);

--- a/src/base.ts
+++ b/src/base.ts
@@ -18,7 +18,8 @@ const formatApiError = (
   const title = body.title || (raw.Title as string);
   const status = body.status || (raw.Status as number);
   const detail = body.detail || (raw.Detail as string);
-  const errors = 'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
+  const errors =
+    'errors' in body ? body.errors : (raw.Errors as Record<string, string[]>);
 
   if (title) {
     const statusStr = status ? ` [${status}]` : '';

--- a/src/base.ts
+++ b/src/base.ts
@@ -8,6 +8,7 @@ import type {
   Input,
   ParserOutput,
 } from '@oclif/core/lib/interfaces/parser';
+import { loadConfig } from './config';
 
 const formatApiError = (
   body: BasisTheory.ValidationProblemDetails | BasisTheory.ProblemDetails
@@ -51,7 +52,6 @@ export abstract class BaseCommand extends Command {
       env: 'BT_MANAGEMENT_KEY',
       description:
         'management key used for connecting with the reactor / proxy',
-      required: true,
     }),
     'api-base-url': Flags.string({
       env: 'BT_API_BASE_URL',
@@ -77,12 +77,23 @@ export abstract class BaseCommand extends Command {
     }
   > {
     const { flags, ...parsed } = await super.parse(options, argv);
+    const config = loadConfig();
     const { 'management-key': managementKey, 'api-base-url': apiBaseUrl } =
       flags;
 
+    const effectiveKey = managementKey || config.managementApiKey;
+
+    if (!effectiveKey) {
+      throw new Errors.CLIError(
+        '--management-key (BT_MANAGEMENT_KEY) must be provided via flag, environment variable, or ~/.basistheory/cli.json.'
+      );
+    }
+
+    const effectiveBaseUrl = apiBaseUrl || config.apiBaseUrl;
+
     const bt = new BasisTheoryClient({
-      apiKey: managementKey,
-      ...(apiBaseUrl ? { environment: apiBaseUrl } : {}),
+      apiKey: effectiveKey,
+      ...(effectiveBaseUrl ? { environment: effectiveBaseUrl } : {}),
     });
 
     return {

--- a/src/base.ts
+++ b/src/base.ts
@@ -93,7 +93,7 @@ export abstract class BaseCommand extends Command {
 
     const bt = new BasisTheoryClient({
       apiKey: effectiveKey,
-      ...(effectiveBaseUrl ? { environment: effectiveBaseUrl } : {}),
+      ...(effectiveBaseUrl ? { baseUrl: effectiveBaseUrl } : {}),
     });
 
     return {

--- a/src/commands/3ds/sessions/authenticate.ts
+++ b/src/commands/3ds/sessions/authenticate.ts
@@ -1,0 +1,42 @@
+import { Args, Flags } from '@oclif/core';
+import type { BasisTheory } from '@basis-theory/node-sdk';
+import { ApiCommand } from '../../../api-command';
+import { requireJsonInput } from '../../../json-input';
+
+export default class Authenticate extends ApiCommand {
+  public static description = 'Authenticate a 3DS session';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> sess-123 --data \'{"authenticationCategory":"payment"}\'',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: '3DS session id to authenticate',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    data: Flags.string({
+      description: 'authentication request as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing authentication request',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags,
+    } = await this.parse(Authenticate);
+
+    const request = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const result = await bt.threeds.sessions.authenticate(id, request as BasisTheory.AuthenticateThreeDsSessionRequest);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/3ds/sessions/authenticate.ts
+++ b/src/commands/3ds/sessions/authenticate.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import type { BasisTheory } from '@basis-theory/node-sdk';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
 import { requireJsonInput } from '../../../json-input';
 
@@ -33,9 +33,15 @@ export default class Authenticate extends ApiCommand {
       flags,
     } = await this.parse(Authenticate);
 
-    const request = requireJsonInput({ data: flags.data, file: flags.file });
+    const request = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
-    const result = await bt.threeds.sessions.authenticate(id, request as BasisTheory.AuthenticateThreeDsSessionRequest);
+    const result = await bt.threeds.sessions.authenticate(
+      id,
+      request as BasisTheory.AuthenticateThreeDsSessionRequest
+    );
 
     this.logJson(result);
   }

--- a/src/commands/3ds/sessions/challenge-result.ts
+++ b/src/commands/3ds/sessions/challenge-result.ts
@@ -4,9 +4,7 @@ import { ApiCommand } from '../../../api-command';
 export default class ChallengeResult extends ApiCommand {
   public static description = 'Get a 3DS session challenge result';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> sess-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> sess-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/3ds/sessions/challenge-result.ts
+++ b/src/commands/3ds/sessions/challenge-result.ts
@@ -1,0 +1,28 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class ChallengeResult extends ApiCommand {
+  public static description = 'Get a 3DS session challenge result';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> sess-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: '3DS session id',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(ChallengeResult);
+
+    const result = await bt.threeds.sessions.getChallengeResult(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/3ds/sessions/create.ts
+++ b/src/commands/3ds/sessions/create.ts
@@ -1,0 +1,47 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+import { readJsonInput } from '../../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a 3DS session';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'token-id': Flags.string({
+      description: 'token ID to use',
+    }),
+    'token-intent-id': Flags.string({
+      description: 'token intent ID to use',
+    }),
+    type: Flags.string({
+      description: 'session type',
+    }),
+    device: Flags.string({
+      description: 'device type',
+    }),
+    data: Flags.string({
+      description: 'session request as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing session request',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const jsonData = readJsonInput({ data: flags.data, file: flags.file });
+
+    const request = jsonData ?? {
+      tokenId: flags['token-id'],
+      tokenIntentId: flags['token-intent-id'],
+      type: flags.type,
+      device: flags.device,
+    };
+
+    const session = await bt.threeds.sessions.create(request);
+
+    this.logJson(session);
+  }
+}

--- a/src/commands/3ds/sessions/create.ts
+++ b/src/commands/3ds/sessions/create.ts
@@ -31,7 +31,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const jsonData = readJsonInput({ data: flags.data, file: flags.file });
+    const jsonData = readJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const request = jsonData ?? {
       tokenId: flags['token-id'],

--- a/src/commands/3ds/sessions/get.ts
+++ b/src/commands/3ds/sessions/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a 3DS session by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> sess-123'];
+
+  public static args = {
+    id: Args.string({
+      description: '3DS session id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const session = await bt.threeds.sessions.get(id);
+
+    this.logJson(session);
+  }
+}

--- a/src/commands/account-updater/jobs/create.ts
+++ b/src/commands/account-updater/jobs/create.ts
@@ -1,0 +1,16 @@
+import { ApiCommand } from '../../../api-command';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create an account updater job';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Create);
+
+    const job = await bt.accountUpdater.jobs.create();
+
+    this.log('Job created successfully!');
+    this.logJson(job);
+  }
+}

--- a/src/commands/account-updater/jobs/get.ts
+++ b/src/commands/account-updater/jobs/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get an account updater job by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> job-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Job id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const job = await bt.accountUpdater.jobs.get(id);
+
+    this.logJson(job);
+  }
+}

--- a/src/commands/account-updater/jobs/index.ts
+++ b/src/commands/account-updater/jobs/index.ts
@@ -1,0 +1,37 @@
+import { Flags, ux } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Jobs extends ApiCommand {
+  public static description = 'List account updater jobs';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    size: Flags.integer({
+      description: 'number of jobs to return',
+      default: 20,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { size },
+    } = await this.parse(Jobs);
+
+    const jobs = await bt.accountUpdater.jobs.list({ size });
+
+    if (!jobs.data?.length) {
+      this.log('No jobs found.');
+
+      return;
+    }
+
+    ux.table(jobs.data as unknown as Record<string, unknown>[], {
+      id: {},
+      status: {},
+      createdAt: { header: 'created_at' },
+      expiresAt: { header: 'expires_at' },
+    });
+  }
+}

--- a/src/commands/account-updater/real-time.ts
+++ b/src/commands/account-updater/real-time.ts
@@ -1,0 +1,47 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class RealTime extends ApiCommand {
+  public static description = 'Invoke account updater real-time';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --token-id tok-123',
+  ];
+
+  public static flags = {
+    'token-id': Flags.string({
+      description: 'token ID to update',
+      required: true,
+    }),
+    'expiration-month': Flags.integer({
+      description: 'expiration month',
+    }),
+    'expiration-year': Flags.integer({
+      description: 'expiration year',
+    }),
+    'deduplicate-token': Flags.boolean({
+      description: 'deduplicate token',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: {
+        'token-id': tokenId,
+        'expiration-month': expirationMonth,
+        'expiration-year': expirationYear,
+        'deduplicate-token': deduplicateToken,
+      },
+    } = await this.parse(RealTime);
+
+    const result = await bt.accountUpdater.realTime.invoke({
+      tokenId,
+      expirationMonth,
+      expirationYear,
+      deduplicateToken,
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/create.ts
+++ b/src/commands/apple-pay/create.ts
@@ -1,5 +1,5 @@
-import { Flags } from '@oclif/core';
 import type { BasisTheory } from '@basis-theory/node-sdk';
+import { Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 import { requireJsonInput } from '../../json-input';
 
@@ -26,7 +26,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const data = requireJsonInput({ data: flags.data, file: flags.file });
+    const data = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const result = await bt.applePay.create({
       applePaymentData: data as BasisTheory.ApplePayMethodToken,

--- a/src/commands/apple-pay/create.ts
+++ b/src/commands/apple-pay/create.ts
@@ -1,0 +1,39 @@
+import { Flags } from '@oclif/core';
+import type { BasisTheory } from '@basis-theory/node-sdk';
+import { ApiCommand } from '../../api-command';
+import { requireJsonInput } from '../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create an Apple Pay token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    data: Flags.string({
+      description: 'Apple payment data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing Apple payment data',
+    }),
+    'expires-at': Flags.string({
+      description: 'expiration date for the token',
+    }),
+    'merchant-registration-id': Flags.string({
+      description: 'merchant registration ID',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const data = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const result = await bt.applePay.create({
+      applePaymentData: data as BasisTheory.ApplePayMethodToken,
+      expiresAt: flags['expires-at'],
+      merchantRegistrationId: flags['merchant-registration-id'],
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/delete.ts
+++ b/src/commands/apple-pay/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -26,19 +25,7 @@ export default class Delete extends ApiCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Apple Pay token (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.applePay.delete(id);
 

--- a/src/commands/apple-pay/delete.ts
+++ b/src/commands/apple-pay/delete.ts
@@ -1,0 +1,47 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete an Apple Pay token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> ap-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Apple Pay token id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Apple Pay token (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.applePay.delete(id);
+
+    this.log('Apple Pay token deleted successfully!');
+  }
+}

--- a/src/commands/apple-pay/delete.ts
+++ b/src/commands/apple-pay/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/apple-pay/domains/deregister.ts
+++ b/src/commands/apple-pay/domains/deregister.ts
@@ -1,0 +1,25 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Deregister extends ApiCommand {
+  public static description = 'Deregister an Apple Pay domain';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    domain: Flags.string({
+      description: 'domain to deregister',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Deregister);
+
+    await bt.applePay.domain.deregister({
+      domain: flags.domain,
+    });
+
+    this.log('Domain deregistered successfully!');
+  }
+}

--- a/src/commands/apple-pay/domains/index.ts
+++ b/src/commands/apple-pay/domains/index.ts
@@ -1,0 +1,15 @@
+import { ApiCommand } from '../../../api-command';
+
+export default class Domains extends ApiCommand {
+  public static description = 'List registered Apple Pay domains';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Domains);
+
+    const result = await bt.applePay.domain.get();
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/domains/register.ts
+++ b/src/commands/apple-pay/domains/register.ts
@@ -1,0 +1,25 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Register extends ApiCommand {
+  public static description = 'Register an Apple Pay domain';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    domain: Flags.string({
+      description: 'domain to register',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Register);
+
+    const result = await bt.applePay.domain.register({
+      domain: flags.domain,
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/get.ts
+++ b/src/commands/apple-pay/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get an Apple Pay token by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> ap-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Apple Pay token id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const result = await bt.applePay.get(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/merchants/certificates/create.ts
+++ b/src/commands/apple-pay/merchants/certificates/create.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'fs';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Create extends ApiCommand {
+  public static description =
+    'Create Apple Pay merchant certificates';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Apple Pay merchant id',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    'merchant-cert': Flags.string({
+      description: 'path to merchant P12 certificate file',
+      required: true,
+    }),
+    'merchant-cert-password': Flags.string({
+      description: 'password for the merchant certificate',
+      required: true,
+    }),
+    'processor-cert': Flags.string({
+      description: 'path to processor certificate file',
+      required: true,
+    }),
+    'processor-cert-password': Flags.string({
+      description: 'password for the processor certificate',
+      required: true,
+    }),
+    domain: Flags.string({
+      description: 'domain for the certificate',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args, flags } = await this.parse(Create);
+
+    const merchantCertificateData = readFileSync(
+      flags['merchant-cert']
+    ).toString('base64');
+    const paymentProcessorCertificateData = readFileSync(
+      flags['processor-cert']
+    ).toString('base64');
+
+    const result = await bt.applePay.merchant.certificates.create(
+      args['merchant-id'],
+      {
+        merchantCertificateData,
+        merchantCertificatePassword: flags['merchant-cert-password'],
+        paymentProcessorCertificateData,
+        paymentProcessorCertificatePassword: flags['processor-cert-password'],
+        domain: flags.domain,
+      }
+    );
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/merchants/certificates/create.ts
+++ b/src/commands/apple-pay/merchants/certificates/create.ts
@@ -1,10 +1,9 @@
-import { readFileSync } from 'fs';
 import { Args, Flags } from '@oclif/core';
+import { readFileSync } from 'fs';
 import { ApiCommand } from '../../../../api-command';
 
 export default class Create extends ApiCommand {
-  public static description =
-    'Create Apple Pay merchant certificates';
+  public static description = 'Create Apple Pay merchant certificates';
 
   public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
 

--- a/src/commands/apple-pay/merchants/certificates/delete.ts
+++ b/src/commands/apple-pay/merchants/certificates/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../../api-command';
 
@@ -29,18 +28,7 @@ export default class Delete extends ApiCommand {
   };
 
   public async run(): Promise<void> {
-    const { bt, args, flags } = await this.parse(Delete);
-
-    if (!flags.force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this certificate (${args['certificate-id']})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
+    const { bt, args } = await this.parse(Delete);
 
     await bt.applePay.merchant.certificates.delete(
       args['merchant-id'],

--- a/src/commands/apple-pay/merchants/certificates/delete.ts
+++ b/src/commands/apple-pay/merchants/certificates/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/apple-pay/merchants/certificates/delete.ts
+++ b/src/commands/apple-pay/merchants/certificates/delete.ts
@@ -1,0 +1,52 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete Apple Pay merchant certificates';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> merch-123 cert-456',
+  ];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Apple Pay merchant id',
+      required: true,
+    }),
+    'certificate-id': Args.string({
+      description: 'certificate id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args, flags } = await this.parse(Delete);
+
+    if (!flags.force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this certificate (${args['certificate-id']})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.applePay.merchant.certificates.delete(
+      args['merchant-id'],
+      args['certificate-id']
+    );
+
+    this.log('Apple Pay merchant certificate deleted successfully!');
+  }
+}

--- a/src/commands/apple-pay/merchants/certificates/get.ts
+++ b/src/commands/apple-pay/merchants/certificates/get.ts
@@ -1,0 +1,32 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get Apple Pay merchant certificates';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> merch-123 cert-456',
+  ];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Apple Pay merchant id',
+      required: true,
+    }),
+    'certificate-id': Args.string({
+      description: 'certificate id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args } = await this.parse(Get);
+
+    const result = await bt.applePay.merchant.certificates.get(
+      args['merchant-id'],
+      args['certificate-id']
+    );
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/merchants/create.ts
+++ b/src/commands/apple-pay/merchants/create.ts
@@ -1,0 +1,25 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create an Apple Pay merchant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'merchant-identifier': Flags.string({
+      description: 'merchant identifier',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const result = await bt.applePay.merchant.create({
+      merchantIdentifier: flags['merchant-identifier'],
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/merchants/delete.ts
+++ b/src/commands/apple-pay/merchants/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
 
@@ -26,19 +25,7 @@ export default class Delete extends ApiCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Apple Pay merchant (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.applePay.merchant.delete(id);
 

--- a/src/commands/apple-pay/merchants/delete.ts
+++ b/src/commands/apple-pay/merchants/delete.ts
@@ -1,0 +1,47 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete an Apple Pay merchant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Apple Pay merchant id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Apple Pay merchant (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.applePay.merchant.delete(id);
+
+    this.log('Apple Pay merchant deleted successfully!');
+  }
+}

--- a/src/commands/apple-pay/merchants/delete.ts
+++ b/src/commands/apple-pay/merchants/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/apple-pay/merchants/get.ts
+++ b/src/commands/apple-pay/merchants/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get an Apple Pay merchant by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Apple Pay merchant id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const result = await bt.applePay.merchant.get(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/apple-pay/session.ts
+++ b/src/commands/apple-pay/session.ts
@@ -1,0 +1,38 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Session extends ApiCommand {
+  public static description = 'Create an Apple Pay session';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'display-name': Flags.string({
+      description: 'display name for the session',
+      required: true,
+    }),
+    domain: Flags.string({
+      description: 'domain for the session',
+      required: true,
+    }),
+    'validation-url': Flags.string({
+      description: 'validation URL for the session',
+    }),
+    'merchant-registration-id': Flags.string({
+      description: 'merchant registration ID',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Session);
+
+    const result = await bt.applePay.session.create({
+      displayName: flags['display-name'],
+      domain: flags.domain,
+      validationUrl: flags['validation-url'],
+      merchantRegistrationId: flags['merchant-registration-id'],
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/applications/create.ts
+++ b/src/commands/applications/create.ts
@@ -2,16 +2,9 @@ import { Flags } from '@oclif/core';
 import {
   createApplication,
   createApplicationFromTemplate,
-  listPermissions,
-  promptTemplate,
 } from '../../applications/management';
 import { APPLICATION_FLAGS } from '../../applications/utils';
 import { BaseCommand } from '../../base';
-import {
-  promptCheckboxIfUndefined,
-  promptSelectIfUndefined,
-  promptStringIfUndefined,
-} from '../../utils';
 
 const APPLICATION_TYPES = ['private', 'public', 'management'] as const;
 
@@ -42,54 +35,21 @@ export default class Create extends BaseCommand {
     let application;
 
     if (flags.template) {
-      // template passed as flag
       application = await createApplicationFromTemplate(bt, flags.template);
     } else {
-      let template;
-      let rules, permissions, type;
-
-      if (!flags.name && !flags.type && !flags.permission) {
-        // no other flags where passed, prompt template
-        template = await promptTemplate(bt);
-      }
-
-      const name = await promptStringIfUndefined(flags.name, {
-        message: 'What is the Application name?',
-        default: template?.name,
-        validate: (value) => Boolean(value),
-      });
-
-      if (template) {
-        // template has been picked, so type and permissions/rules are defined
-        type = template.applicationType;
-        rules = template.rules;
-        permissions = template.permissions;
-      } else {
-        type = (await promptSelectIfUndefined(flags.type, {
-          message: 'What is the Application type?',
-          choices: APPLICATION_TYPES.map((t) => ({ value: t })),
-        })) as ApplicationType;
-
-        const available = await listPermissions(bt, type);
-
-        permissions = await promptCheckboxIfUndefined(flags.permission, {
-          message: 'Select the permissions for the Application',
-          choices: available.map((p) => ({
-            value: p.type,
-          })),
-          loop: false,
-        });
-      }
+      const name = flags.name ?? '';
+      const type = (flags.type ?? '') as ApplicationType;
 
       if (!type) {
         throw new Error('Application type is required');
       }
 
+      const permissions = flags.permission ?? [];
+
       application = await createApplication(bt, {
         name,
         type,
         permissions,
-        rules,
       });
     }
 

--- a/src/commands/applications/delete.ts
+++ b/src/commands/applications/delete.ts
@@ -29,11 +29,10 @@ export default class Delete extends BaseCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { yes },
       args: { id },
     } = await this.parse(Delete);
 
-    if (await deleteApplication(bt, id, yes)) {
+    if (await deleteApplication(bt, id)) {
       this.log('Application deleted successfully!');
     }
   }

--- a/src/commands/applications/index.ts
+++ b/src/commands/applications/index.ts
@@ -1,9 +1,4 @@
-import select from '@inquirer/select';
-import { Flags } from '@oclif/core';
-import {
-  deleteApplication,
-  selectApplication,
-} from '../../applications/management';
+import { Flags, ux } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
 export default class Applications extends BaseCommand {
@@ -18,47 +13,41 @@ export default class Applications extends BaseCommand {
       description: 'Applications list page to fetch',
       default: 1,
     }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
   };
 
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { page },
+      flags: { page, size, json },
     } = await this.parse(Applications);
 
-    const application = await selectApplication(bt, page);
-
-    if (!application) {
-      return undefined;
-    }
-
-    const action = await select({
-      message: 'Select action to perform',
-      choices: [
-        {
-          name: 'See details',
-          value: 'details',
-        },
-        {
-          name: 'Delete',
-          value: 'delete',
-        },
-      ],
+    const applications = await bt.applications.list({
+      page,
+      size,
     });
 
-    if (action === 'details') {
-      this.logJson(application);
+    if (json) {
+      this.logJson(applications);
 
-      return undefined;
+      return;
     }
 
-    if (
-      action === 'delete' &&
-      (await deleteApplication(bt, application.id ?? ''))
-    ) {
-      return this.log('Application deleted successfully!');
+    if (!applications.data.length) {
+      this.log('No applications found.');
+
+      return;
     }
 
-    return undefined;
+    ux.table(applications.data as unknown as Record<string, unknown>[], {
+      id: {},
+      name: {},
+      type: {},
+      createdAt: { header: 'Created At' },
+    });
   }
 }

--- a/src/commands/connections/stripe-forward/tokenize.ts
+++ b/src/commands/connections/stripe-forward/tokenize.ts
@@ -21,12 +21,13 @@ export default class Tokenize extends ApiCommand {
   public async run(): Promise<void> {
     const { flags } = await this.parse(Tokenize);
 
-    const data = requireJsonInput({ data: flags.data, file: flags.file });
+    const data = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
-    const apiKey =
-      flags['api-key'] || flags['management-key'];
-    const baseUrl =
-      flags['api-base-url'] || 'https://api.basistheory.com';
+    const apiKey = flags['api-key'] || flags['management-key'];
+    const baseUrl = flags['api-base-url'] || 'https://api.basistheory.com';
 
     const response = await fetch(
       `${baseUrl}/connections/stripe-forward/tokenize`,

--- a/src/commands/connections/stripe-forward/tokenize.ts
+++ b/src/commands/connections/stripe-forward/tokenize.ts
@@ -1,5 +1,6 @@
 import { Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
+import { loadConfig } from '../../../config';
 import { requireJsonInput } from '../../../json-input';
 
 export default class Tokenize extends ApiCommand {
@@ -26,15 +27,30 @@ export default class Tokenize extends ApiCommand {
       file: flags.file,
     });
 
-    const apiKey = flags['api-key'] || flags['management-key'];
-    const baseUrl = flags['api-base-url'] || 'https://api.basistheory.com';
+    const config = loadConfig();
+    const apiKey =
+      flags['api-key'] ||
+      flags['management-key'] ||
+      config.apiKey ||
+      config.managementApiKey;
+
+    if (!apiKey) {
+      this.error(
+        'Either --api-key (BT_API_KEY) or --management-key (BT_MANAGEMENT_KEY) must be provided.'
+      );
+    }
+
+    const baseUrl =
+      flags['api-base-url'] ||
+      config.apiBaseUrl ||
+      'https://api.basistheory.com';
 
     const response = await fetch(
       `${baseUrl}/connections/stripe-forward/tokenize`,
       {
         method: 'POST',
         headers: {
-          'BT-API-KEY': apiKey!,
+          'BT-API-KEY': apiKey,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(data),

--- a/src/commands/connections/stripe-forward/tokenize.ts
+++ b/src/commands/connections/stripe-forward/tokenize.ts
@@ -1,0 +1,53 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+import { requireJsonInput } from '../../../json-input';
+
+export default class Tokenize extends ApiCommand {
+  public static description = 'Forward tokenize via Stripe connection';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --data \'{"number":"4242424242424242"}\'',
+  ];
+
+  public static flags = {
+    data: Flags.string({
+      description: 'card data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing card data',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(Tokenize);
+
+    const data = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const apiKey =
+      flags['api-key'] || flags['management-key'];
+    const baseUrl =
+      flags['api-base-url'] || 'https://api.basistheory.com';
+
+    const response = await fetch(
+      `${baseUrl}/connections/stripe-forward/tokenize`,
+      {
+        method: 'POST',
+        headers: {
+          'BT-API-KEY': apiKey!,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }
+    );
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+
+      this.error(`Request failed with status ${response.status}: ${errorBody}`);
+    }
+
+    const result = await response.json();
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/detokenize.ts
+++ b/src/commands/detokenize.ts
@@ -21,7 +21,10 @@ export default class Detokenize extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Detokenize);
 
-    const input = requireJsonInput({ data: flags.data, file: flags.file });
+    const input = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const result = await bt.tokens.detokenize(input);
 

--- a/src/commands/detokenize.ts
+++ b/src/commands/detokenize.ts
@@ -1,0 +1,30 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../api-command';
+import { requireJsonInput } from '../json-input';
+
+export default class Detokenize extends ApiCommand {
+  public static description = 'Detokenize data';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --data \'{"token_id":"tok-123"}\'',
+  ];
+
+  public static flags = {
+    data: Flags.string({
+      description: 'JSON data to detokenize',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing data to detokenize',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Detokenize);
+
+    const input = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const result = await bt.tokens.detokenize(input);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/documents/delete.ts
+++ b/src/commands/documents/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -28,19 +27,7 @@ export default class Delete extends ApiCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Document (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.documents.delete(id);
 

--- a/src/commands/documents/delete.ts
+++ b/src/commands/documents/delete.ts
@@ -1,0 +1,49 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Deletes a document';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> doc-123',
+    '<%= config.bin %> <%= command.id %> doc-123 --force',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Document ID',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      description: 'skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Document (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.documents.delete(id);
+
+    this.log('Document deleted successfully!');
+  }
+}

--- a/src/commands/documents/delete.ts
+++ b/src/commands/documents/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/documents/download.ts
+++ b/src/commands/documents/download.ts
@@ -1,6 +1,6 @@
+import { Args, Flags } from '@oclif/core';
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
-import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
 export default class Download extends ApiCommand {

--- a/src/commands/documents/download.ts
+++ b/src/commands/documents/download.ts
@@ -1,0 +1,47 @@
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Download extends ApiCommand {
+  public static description = 'Downloads a document by ID';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> doc-123',
+    '<%= config.bin %> <%= command.id %> doc-123 --output ./downloaded.pdf',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Document ID',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    output: Flags.string({
+      description: 'output file path',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { output },
+    } = await this.parse(Download);
+
+    const response = await bt.documents.data.get(id);
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    if (output) {
+      const outputPath = resolve(process.cwd(), output);
+
+      writeFileSync(outputPath, buffer);
+      this.log(`Document downloaded to ${outputPath}`);
+    } else {
+      process.stdout.write(buffer);
+    }
+  }
+}

--- a/src/commands/documents/get.ts
+++ b/src/commands/documents/get.ts
@@ -4,9 +4,7 @@ import { ApiCommand } from '../../api-command';
 export default class Get extends ApiCommand {
   public static description = 'Gets a document by ID';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> doc-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> doc-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/documents/get.ts
+++ b/src/commands/documents/get.ts
@@ -1,0 +1,28 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Gets a document by ID';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> doc-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Document ID',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const document = await bt.documents.get(id);
+
+    this.logJson(document);
+  }
+}

--- a/src/commands/documents/upload.ts
+++ b/src/commands/documents/upload.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import type { BasisTheory } from '@basis-theory/node-sdk';
 import { Flags } from '@oclif/core';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { ApiCommand } from '../../api-command';
 
 export default class Upload extends ApiCommand {

--- a/src/commands/documents/upload.ts
+++ b/src/commands/documents/upload.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { BasisTheory } from '@basis-theory/node-sdk';
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Upload extends ApiCommand {
+  public static description = 'Uploads a document';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --file ./document.pdf',
+    '<%= config.bin %> <%= command.id %> --file ./document.pdf --metadata key1=value1 --metadata key2=value2',
+  ];
+
+  public static flags = {
+    file: Flags.string({
+      description: 'path to the document file',
+      required: true,
+    }),
+    metadata: Flags.string({
+      description: 'metadata key=value pairs',
+      multiple: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { file, metadata },
+    } = await this.parse(Upload);
+
+    const filePath = resolve(process.cwd(), file);
+    const fileBuffer = readFileSync(filePath);
+
+    let request: BasisTheory.CreateDocumentRequest | undefined;
+
+    if (metadata && metadata.length > 0) {
+      const metadataObj: Record<string, string> = {};
+
+      for (const entry of metadata) {
+        const [key, ...valueParts] = entry.split('=');
+
+        metadataObj[key] = valueParts.join('=');
+      }
+
+      request = { metadata: metadataObj };
+    }
+
+    const result = await bt.documents.upload({
+      document: fileBuffer,
+      request,
+    });
+
+    this.log('Document uploaded successfully!');
+    this.logJson(result);
+  }
+}

--- a/src/commands/enrichments/bank-account-verify.ts
+++ b/src/commands/enrichments/bank-account-verify.ts
@@ -1,0 +1,43 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class BankAccountVerify extends ApiCommand {
+  public static description = 'Verify a bank account';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --token-id tok-123',
+  ];
+
+  public static flags = {
+    'token-id': Flags.string({
+      description: 'token ID for the bank account',
+      required: true,
+    }),
+    'country-code': Flags.string({
+      description: 'country code',
+      default: 'US',
+    }),
+    'routing-number': Flags.string({
+      description: 'routing number',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: {
+        'token-id': tokenId,
+        'country-code': countryCode,
+        'routing-number': routingNumber,
+      },
+    } = await this.parse(BankAccountVerify);
+
+    const result = await bt.enrichments.bankAccountVerify({
+      tokenId,
+      countryCode,
+      routingNumber,
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/create.ts
+++ b/src/commands/google-pay/create.ts
@@ -1,0 +1,39 @@
+import { Flags } from '@oclif/core';
+import type { BasisTheory } from '@basis-theory/node-sdk';
+import { ApiCommand } from '../../api-command';
+import { requireJsonInput } from '../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a Google Pay token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    data: Flags.string({
+      description: 'Google payment data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing Google payment data',
+    }),
+    'expires-at': Flags.string({
+      description: 'expiration date for the token',
+    }),
+    'merchant-registration-id': Flags.string({
+      description: 'merchant registration ID',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const data = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const result = await bt.googlePay.create({
+      googlePaymentData: data as BasisTheory.GooglePayMethodToken,
+      expiresAt: flags['expires-at'],
+      merchantRegistrationId: flags['merchant-registration-id'],
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/create.ts
+++ b/src/commands/google-pay/create.ts
@@ -1,5 +1,5 @@
-import { Flags } from '@oclif/core';
 import type { BasisTheory } from '@basis-theory/node-sdk';
+import { Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 import { requireJsonInput } from '../../json-input';
 
@@ -26,7 +26,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const data = requireJsonInput({ data: flags.data, file: flags.file });
+    const data = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const result = await bt.googlePay.create({
       googlePaymentData: data as BasisTheory.GooglePayMethodToken,

--- a/src/commands/google-pay/delete.ts
+++ b/src/commands/google-pay/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -26,19 +25,7 @@ export default class Delete extends ApiCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Google Pay token (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.googlePay.delete(id);
 

--- a/src/commands/google-pay/delete.ts
+++ b/src/commands/google-pay/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/google-pay/delete.ts
+++ b/src/commands/google-pay/delete.ts
@@ -1,0 +1,47 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete a Google Pay token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> gp-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Google Pay token id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Google Pay token (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.googlePay.delete(id);
+
+    this.log('Google Pay token deleted successfully!');
+  }
+}

--- a/src/commands/google-pay/get.ts
+++ b/src/commands/google-pay/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a Google Pay token by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> gp-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Google Pay token id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const result = await bt.googlePay.get(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/merchants/certificates/create.ts
+++ b/src/commands/google-pay/merchants/certificates/create.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'fs';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create Google Pay merchant certificates';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Google Pay merchant id',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    'merchant-cert': Flags.string({
+      description: 'path to merchant certificate file',
+      required: true,
+    }),
+    'merchant-cert-password': Flags.string({
+      description: 'password for the merchant certificate',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args, flags } = await this.parse(Create);
+
+    const merchantCertificateData = readFileSync(
+      flags['merchant-cert']
+    ).toString('base64');
+
+    const result = await bt.googlePay.merchant.certificates.create(
+      args['merchant-id'],
+      {
+        merchantCertificateData,
+        merchantCertificatePassword: flags['merchant-cert-password'],
+      }
+    );
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/merchants/certificates/create.ts
+++ b/src/commands/google-pay/merchants/certificates/create.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'fs';
 import { Args, Flags } from '@oclif/core';
+import { readFileSync } from 'fs';
 import { ApiCommand } from '../../../../api-command';
 
 export default class Create extends ApiCommand {

--- a/src/commands/google-pay/merchants/certificates/delete.ts
+++ b/src/commands/google-pay/merchants/certificates/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../../api-command';
 
@@ -29,18 +28,7 @@ export default class Delete extends ApiCommand {
   };
 
   public async run(): Promise<void> {
-    const { bt, args, flags } = await this.parse(Delete);
-
-    if (!flags.force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this certificate (${args['certificate-id']})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
+    const { bt, args } = await this.parse(Delete);
 
     await bt.googlePay.merchant.certificates.delete(
       args['merchant-id'],

--- a/src/commands/google-pay/merchants/certificates/delete.ts
+++ b/src/commands/google-pay/merchants/certificates/delete.ts
@@ -1,0 +1,52 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete Google Pay merchant certificates';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> merch-123 cert-456',
+  ];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Google Pay merchant id',
+      required: true,
+    }),
+    'certificate-id': Args.string({
+      description: 'certificate id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args, flags } = await this.parse(Delete);
+
+    if (!flags.force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this certificate (${args['certificate-id']})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.googlePay.merchant.certificates.delete(
+      args['merchant-id'],
+      args['certificate-id']
+    );
+
+    this.log('Google Pay merchant certificate deleted successfully!');
+  }
+}

--- a/src/commands/google-pay/merchants/certificates/delete.ts
+++ b/src/commands/google-pay/merchants/certificates/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/google-pay/merchants/certificates/get.ts
+++ b/src/commands/google-pay/merchants/certificates/get.ts
@@ -1,0 +1,32 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get Google Pay merchant certificates';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> merch-123 cert-456',
+  ];
+
+  public static args = {
+    'merchant-id': Args.string({
+      description: 'Google Pay merchant id',
+      required: true,
+    }),
+    'certificate-id': Args.string({
+      description: 'certificate id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, args } = await this.parse(Get);
+
+    const result = await bt.googlePay.merchant.certificates.get(
+      args['merchant-id'],
+      args['certificate-id']
+    );
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/merchants/create.ts
+++ b/src/commands/google-pay/merchants/create.ts
@@ -1,0 +1,25 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a Google Pay merchant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'merchant-identifier': Flags.string({
+      description: 'merchant identifier',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const result = await bt.googlePay.merchant.create({
+      merchantIdentifier: flags['merchant-identifier'],
+    });
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/google-pay/merchants/delete.ts
+++ b/src/commands/google-pay/merchants/delete.ts
@@ -1,0 +1,47 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { ApiCommand } from '../../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete a Google Pay merchant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Google Pay merchant id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Google Pay merchant (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.googlePay.merchant.delete(id);
+
+    this.log('Google Pay merchant deleted successfully!');
+  }
+}

--- a/src/commands/google-pay/merchants/delete.ts
+++ b/src/commands/google-pay/merchants/delete.ts
@@ -1,5 +1,5 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
 
 export default class Delete extends ApiCommand {

--- a/src/commands/google-pay/merchants/delete.ts
+++ b/src/commands/google-pay/merchants/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../../api-command';
 
@@ -26,19 +25,7 @@ export default class Delete extends ApiCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Google Pay merchant (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.googlePay.merchant.delete(id);
 

--- a/src/commands/google-pay/merchants/get.ts
+++ b/src/commands/google-pay/merchants/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a Google Pay merchant by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> merch-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Google Pay merchant id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const result = await bt.googlePay.merchant.get(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/keys/create.ts
+++ b/src/commands/keys/create.ts
@@ -1,0 +1,28 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Create extends BaseCommand {
+  public static description = 'Create a new client encryption key';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'expires-at': Flags.string({
+      description: 'expiration date for the key',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { 'expires-at': expiresAt },
+    } = await this.parse(Create);
+
+    const key = await bt.keys.create({
+      expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+    });
+
+    this.log('Key created successfully!');
+    this.logJson(key);
+  }
+}

--- a/src/commands/keys/delete.ts
+++ b/src/commands/keys/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
@@ -26,19 +25,7 @@ export default class Delete extends BaseCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Key (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.keys.delete(id);
 

--- a/src/commands/keys/delete.ts
+++ b/src/commands/keys/delete.ts
@@ -1,0 +1,49 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { BaseCommand } from '../../base';
+
+export default class Delete extends BaseCommand {
+  public static description = 'Delete a client encryption key';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> key-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Key id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Key (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.keys.delete(id);
+
+    this.log('Key deleted successfully!');
+  }
+}

--- a/src/commands/keys/delete.ts
+++ b/src/commands/keys/delete.ts
@@ -1,13 +1,11 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
 export default class Delete extends BaseCommand {
   public static description = 'Delete a client encryption key';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> key-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> key-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/keys/index.ts
+++ b/src/commands/keys/index.ts
@@ -1,0 +1,25 @@
+import { ux } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Keys extends BaseCommand {
+  public static description = 'List client encryption keys';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Keys);
+
+    const keys = await bt.keys.list();
+
+    if (!keys.length) {
+      this.log('No keys found.');
+
+      return;
+    }
+
+    ux.table(keys as unknown as Record<string, unknown>[], {
+      keyId: { header: 'key_id' },
+      expiresAt: { header: 'expires_at' },
+    });
+  }
+}

--- a/src/commands/logs/entity-types.ts
+++ b/src/commands/logs/entity-types.ts
@@ -1,0 +1,25 @@
+import { ux } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class EntityTypes extends BaseCommand {
+  public static description = 'List log entity types';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(EntityTypes);
+
+    const entityTypes = await bt.logs.getEntityTypes();
+
+    if (!entityTypes.length) {
+      this.log('No entity types found.');
+
+      return;
+    }
+
+    ux.table(entityTypes as unknown as Record<string, unknown>[], {
+      displayName: { header: 'display_name' },
+      value: {},
+    });
+  }
+}

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -1,0 +1,57 @@
+import { Flags, ux } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Logs extends BaseCommand {
+  public static description = 'List audit logs';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    'entity-type': Flags.string({
+      description: 'filter by entity type',
+    }),
+    'entity-id': Flags.string({
+      description: 'filter by entity id',
+    }),
+    'start-date': Flags.string({
+      description: 'filter by start date',
+    }),
+    'end-date': Flags.string({
+      description: 'filter by end date',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: {
+        'entity-type': entityType,
+        'entity-id': entityId,
+        'start-date': startDate,
+        'end-date': endDate,
+      },
+    } = await this.parse(Logs);
+
+    const logs = await bt.logs.list({
+      entityType,
+      entityId,
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+    });
+
+    if (!logs.data?.length) {
+      this.log('No logs found.');
+
+      return;
+    }
+
+    ux.table(logs.data as unknown as Record<string, unknown>[], {
+      createdAt: { header: 'created_at' },
+      actorType: { header: 'actor_type' },
+      entityType: { header: 'entity_type' },
+      entityId: { header: 'entity_id' },
+      operation: {},
+      message: {},
+    });
+  }
+}

--- a/src/commands/network-tokens/create.ts
+++ b/src/commands/network-tokens/create.ts
@@ -1,5 +1,5 @@
-import { Flags } from '@oclif/core';
 import type { BasisTheory } from '@basis-theory/node-sdk';
+import { Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 import { readJsonInput } from '../../json-input';
 
@@ -28,7 +28,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const data = readJsonInput({ data: flags.data, file: flags.file });
+    const data = readJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const networkToken = await bt.networkTokens.create({
       tokenId: flags['token-id'],

--- a/src/commands/network-tokens/create.ts
+++ b/src/commands/network-tokens/create.ts
@@ -1,0 +1,41 @@
+import { Flags } from '@oclif/core';
+import type { BasisTheory } from '@basis-theory/node-sdk';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a network token';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --token-id tok-123',
+  ];
+
+  public static flags = {
+    'token-id': Flags.string({
+      description: 'token ID to use',
+    }),
+    'token-intent-id': Flags.string({
+      description: 'token intent ID to use',
+    }),
+    data: Flags.string({
+      description: 'card data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing card data',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const data = readJsonInput({ data: flags.data, file: flags.file });
+
+    const networkToken = await bt.networkTokens.create({
+      tokenId: flags['token-id'],
+      tokenIntentId: flags['token-intent-id'],
+      data: data as BasisTheory.Card,
+    });
+
+    this.logJson(networkToken);
+  }
+}

--- a/src/commands/network-tokens/cryptogram.ts
+++ b/src/commands/network-tokens/cryptogram.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Cryptogram extends ApiCommand {
+  public static description = 'Get a network token cryptogram';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> nt-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Network token id',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Cryptogram);
+
+    const result = await bt.networkTokens.cryptogram(id);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/network-tokens/delete.ts
+++ b/src/commands/network-tokens/delete.ts
@@ -1,0 +1,46 @@
+import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete a network token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> nt-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Network token id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { force },
+      args: { id },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const confirmed = await confirm({
+        message: `Are you sure you want to delete network token ${id}?`,
+      });
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    await bt.networkTokens.delete(id);
+
+    this.log('Network token deleted successfully!');
+  }
+}

--- a/src/commands/network-tokens/delete.ts
+++ b/src/commands/network-tokens/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -25,19 +24,8 @@ export default class Delete extends ApiCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { force },
       args: { id },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const confirmed = await confirm({
-        message: `Are you sure you want to delete network token ${id}?`,
-      });
-
-      if (!confirmed) {
-        return;
-      }
-    }
 
     await bt.networkTokens.delete(id);
 

--- a/src/commands/network-tokens/get.ts
+++ b/src/commands/network-tokens/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a network token by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> nt-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Network token id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const networkToken = await bt.networkTokens.get(id);
+
+    this.logJson(networkToken);
+  }
+}

--- a/src/commands/network-tokens/resume.ts
+++ b/src/commands/network-tokens/resume.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Resume extends ApiCommand {
+  public static description = 'Resume a network token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> nt-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Network token id to resume',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Resume);
+
+    const networkToken = await bt.networkTokens.resume(id);
+
+    this.logJson(networkToken);
+  }
+}

--- a/src/commands/network-tokens/suspend.ts
+++ b/src/commands/network-tokens/suspend.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Suspend extends ApiCommand {
+  public static description = 'Suspend a network token';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> nt-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Network token id to suspend',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Suspend);
+
+    const networkToken = await bt.networkTokens.suspend(id);
+
+    this.logJson(networkToken);
+  }
+}

--- a/src/commands/proxies/create.ts
+++ b/src/commands/proxies/create.ts
@@ -6,16 +6,7 @@ import {
   validateTransformRuntimeFlags,
 } from '../../proxies/runtime';
 import { createModelFromFlags, PROXY_FLAGS } from '../../proxies/utils';
-import {
-  isLegacyRuntimeImage,
-  promptRuntimeImage,
-  waitForResourceState,
-} from '../../runtime';
-import {
-  promptBooleanIfUndefined,
-  promptStringIfUndefined,
-  promptUrlIfUndefined,
-} from '../../utils';
+import { isLegacyRuntimeImage, waitForResourceState } from '../../runtime';
 
 export default class Create extends BaseCommand {
   public static description =
@@ -81,66 +72,31 @@ export default class Create extends BaseCommand {
       flags['response-transform-image']
     );
 
-    const name = await promptStringIfUndefined(flags.name, {
-      message: 'What is the Proxy name?',
-      validate: (value) => Boolean(value),
-    });
-    const destinationUrl = (
-      await promptUrlIfUndefined(flags['destination-url'], {
-        message: 'What is the Proxy destination URL?',
-      })
-    ).toString();
-    const requestTransformCode = await promptStringIfUndefined(
-      flags['request-transform-code'],
-      {
-        message: '(Optional) Enter the Request Transform code file path:',
-      }
-    );
+    const name = flags.name ?? '';
 
-    const requestTransformImage = requestTransformCode
-      ? await promptRuntimeImage(
-          flags['request-transform-image'],
-          'Which runtime do you want for the request transform?'
-        )
-      : flags['request-transform-image'];
+    if (!flags['destination-url']) {
+      throw new Error('--destination-url is required');
+    }
 
-    const responseTransformCode = await promptStringIfUndefined(
-      flags['response-transform-code'],
-      {
-        message: '(Optional) Enter the Response Transform code file path:',
-      }
-    );
-
-    const responseTransformImage = responseTransformCode
-      ? await promptRuntimeImage(
-          flags['response-transform-image'],
-          'Which runtime do you want for the response transform?'
-        )
-      : flags['response-transform-image'];
+    const destinationUrl = flags['destination-url'].toString();
+    const requestTransformCode = flags['request-transform-code'] ?? '';
+    const requestTransformImage = flags['request-transform-image'];
+    const responseTransformCode = flags['response-transform-code'] ?? '';
+    const responseTransformImage = flags['response-transform-image'];
 
     const hasLegacyTransform =
       isLegacyRuntimeImage(requestTransformImage) ||
       isLegacyRuntimeImage(responseTransformImage);
 
     const applicationId = hasLegacyTransform
-      ? await promptStringIfUndefined(flags['application-id'], {
-          message: '(Optional) Enter the Application ID to use in the Proxy:',
-        })
+      ? flags['application-id'] ?? ''
       : flags['application-id'];
 
-    const configuration = await promptStringIfUndefined(flags.configuration, {
-      message: '(Optional) Enter the configuration file path (.env format):',
-    });
+    const configuration = flags.configuration ?? '';
 
-    const requireAuth = await promptBooleanIfUndefined(
-      metadata.flags?.['require-auth']?.setFromDefault
-        ? undefined
-        : flags['require-auth'],
-      {
-        message: 'Does the Proxy require Basis Theory authentication?',
-        default: true,
-      }
-    );
+    const requireAuth = metadata.flags?.['require-auth']?.setFromDefault
+      ? false
+      : flags['require-auth'] ?? false;
 
     const updatedFlags = {
       ...flags,

--- a/src/commands/proxies/delete.ts
+++ b/src/commands/proxies/delete.ts
@@ -29,11 +29,10 @@ export default class Delete extends BaseCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { yes },
       args: { id },
     } = await this.parse(Delete);
 
-    if (await deleteProxy(bt, id, yes)) {
+    if (await deleteProxy(bt, id)) {
       this.log('Proxy deleted successfully!');
     }
   }

--- a/src/commands/proxies/index.ts
+++ b/src/commands/proxies/index.ts
@@ -1,8 +1,5 @@
-import select from '@inquirer/select';
-import { Flags } from '@oclif/core';
+import { Flags, ux } from '@oclif/core';
 import { BaseCommand } from '../../base';
-import { showProxyLogs } from '../../logs';
-import { deleteProxy, selectProxy } from '../../proxies/management';
 
 export default class Proxies extends BaseCommand {
   public static description =
@@ -16,55 +13,52 @@ export default class Proxies extends BaseCommand {
       description: 'Proxies list page to fetch',
       default: 1,
     }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
   };
-
-  public static args = {};
 
   public async run(): Promise<void> {
     const {
-      flags: { page },
       bt,
+      flags: { page, size, json },
     } = await this.parse(Proxies);
 
-    const proxy = await selectProxy(bt, page);
-
-    if (!proxy) {
-      return undefined;
-    }
-
-    const action = await select({
-      message: 'Select action to perform',
-      choices: [
-        {
-          name: 'See details',
-          value: 'details',
-        },
-        {
-          name: 'Logs',
-          value: 'logs',
-          description: 'See Proxy Transforms real-time logs',
-        },
-        {
-          name: 'Delete',
-          value: 'delete',
-        },
-      ],
+    const proxies = await bt.proxies.list({
+      page,
+      size,
     });
 
-    if (action === 'details') {
-      this.logJson(proxy);
+    if (json) {
+      this.logJson(proxies);
 
-      return undefined;
+      return;
     }
 
-    if (action === 'logs') {
-      return showProxyLogs(bt, proxy.id ?? '');
+    if (!proxies.data.length) {
+      this.log('No proxies found.');
+
+      return;
     }
 
-    if (action === 'delete' && (await deleteProxy(bt, proxy.id ?? ''))) {
-      return this.log('Proxy deleted successfully!');
-    }
-
-    return undefined;
+    ux.table(proxies.data as unknown as Record<string, unknown>[], {
+      id: {},
+      name: {},
+      key: {},
+      state: {},
+      /* eslint-disable camelcase */
+      destination_url: {
+        header: 'Destination URL',
+        get: (proxy: Record<string, unknown>) => proxy.destinationUrl as string,
+      },
+      require_auth: {
+        header: 'Require Auth',
+        get: (proxy: Record<string, unknown>) =>
+          proxy.requireAuth ? 'yes' : 'no',
+      },
+      /* eslint-enable camelcase */
+    });
   }
 }

--- a/src/commands/proxies/invoke.ts
+++ b/src/commands/proxies/invoke.ts
@@ -71,7 +71,10 @@ export default class Invoke extends ApiCommand {
       headers['BT-PROXY-KEY'] = proxyKey;
     }
 
-    const body = readJsonInput({ data, file });
+    const body = readJsonInput({
+      data,
+      file,
+    });
 
     const response = await fetch(url, {
       method: method || 'POST',
@@ -82,9 +85,7 @@ export default class Invoke extends ApiCommand {
     const responseText = await response.text();
 
     if (!response.ok) {
-      this.error(
-        `Proxy request failed [${response.status}]: ${responseText}`
-      );
+      this.error(`Proxy request failed [${response.status}]: ${responseText}`);
     }
 
     try {

--- a/src/commands/proxies/invoke.ts
+++ b/src/commands/proxies/invoke.ts
@@ -1,5 +1,6 @@
 import { Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
+import { loadConfig } from '../../config';
 import { readJsonInput } from '../../json-input';
 
 export default class Invoke extends ApiCommand {
@@ -52,14 +53,23 @@ export default class Invoke extends ApiCommand {
       this.error('Either --proxy-url or --proxy-key must be provided.');
     }
 
-    const key = apiKey || managementKey;
+    const config = loadConfig();
+    const key =
+      apiKey || managementKey || config.apiKey || config.managementApiKey;
 
-    const baseUrl = apiBaseUrl || 'https://api.basistheory.com';
+    if (!key) {
+      this.error(
+        'Either --api-key (BT_API_KEY) or --management-key (BT_MANAGEMENT_KEY) must be provided.'
+      );
+    }
+
+    const baseUrl =
+      apiBaseUrl || config.apiBaseUrl || 'https://api.basistheory.com';
     const urlPath = proxyPath ? `/proxy/${proxyPath}` : '/proxy';
     const url = `${baseUrl}${urlPath}`;
 
     const headers: Record<string, string> = {
-      'BT-API-KEY': key!,
+      'BT-API-KEY': key,
       'Content-Type': 'application/json',
     };
 

--- a/src/commands/proxies/invoke.ts
+++ b/src/commands/proxies/invoke.ts
@@ -1,0 +1,98 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class Invoke extends ApiCommand {
+  public static description = 'Invokes a Proxy';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --proxy-key proxy-key-123 --data \'{"key": "value"}\'',
+    '<%= config.bin %> <%= command.id %> --proxy-url https://example.com/api --method GET',
+  ];
+
+  public static flags = {
+    method: Flags.string({
+      description: 'HTTP method to use',
+      default: 'POST',
+      options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+    }),
+    'proxy-url': Flags.string({
+      description: 'destination URL for ephemeral proxy',
+    }),
+    'proxy-key': Flags.string({
+      description: 'key for pre-configured proxy',
+    }),
+    data: Flags.string({
+      description: 'request body as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to a JSON file containing the request body',
+    }),
+    path: Flags.string({
+      description: 'additional path to append to the proxy endpoint',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(Invoke);
+
+    const {
+      method,
+      'proxy-url': proxyUrl,
+      'proxy-key': proxyKey,
+      data,
+      file,
+      path: proxyPath,
+      'api-key': apiKey,
+      'management-key': managementKey,
+      'api-base-url': apiBaseUrl,
+    } = flags;
+
+    if (!proxyUrl && !proxyKey) {
+      this.error('Either --proxy-url or --proxy-key must be provided.');
+    }
+
+    const key = apiKey || managementKey;
+
+    const baseUrl = apiBaseUrl || 'https://api.basistheory.com';
+    const urlPath = proxyPath ? `/proxy/${proxyPath}` : '/proxy';
+    const url = `${baseUrl}${urlPath}`;
+
+    const headers: Record<string, string> = {
+      'BT-API-KEY': key!,
+      'Content-Type': 'application/json',
+    };
+
+    if (proxyUrl) {
+      headers['BT-PROXY-URL'] = proxyUrl;
+    }
+
+    if (proxyKey) {
+      headers['BT-PROXY-KEY'] = proxyKey;
+    }
+
+    const body = readJsonInput({ data, file });
+
+    const response = await fetch(url, {
+      method: method || 'POST',
+      headers,
+      ...(body && method !== 'GET' ? { body: JSON.stringify(body) } : {}),
+    });
+
+    const responseText = await response.text();
+
+    if (!response.ok) {
+      this.error(
+        `Proxy request failed [${response.status}]: ${responseText}`
+      );
+    }
+
+    try {
+      const json = JSON.parse(responseText);
+
+      this.logJson(json);
+    } catch {
+      this.log(responseText);
+    }
+  }
+}

--- a/src/commands/proxies/logs.ts
+++ b/src/commands/proxies/logs.ts
@@ -1,14 +1,12 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 import { DEFAULT_LOGS_SERVER_PORT, showProxyLogs } from '../../logs';
-import { selectProxy } from '../../proxies/management';
 
 export default class Logs extends BaseCommand {
   public static description =
     'Display live Proxy Transform logs output. Requires `proxy:update` Management Application permissions';
 
   public static examples = [
-    '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca',
     '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca -p 3000',
   ];
@@ -16,6 +14,7 @@ export default class Logs extends BaseCommand {
   public static args = {
     id: Args.string({
       description: 'Proxy id to connect to',
+      required: true,
     }),
   };
 
@@ -34,16 +33,6 @@ export default class Logs extends BaseCommand {
       args: { id },
     } = await this.parse(Logs);
 
-    if (id) {
-      return showProxyLogs(bt, id, port);
-    }
-
-    const proxy = await selectProxy(bt, 1);
-
-    if (!proxy) {
-      return undefined;
-    }
-
-    return showProxyLogs(bt, proxy.id ?? '', port);
+    return showProxyLogs(bt, id, port);
   }
 }

--- a/src/commands/reactors/create.ts
+++ b/src/commands/reactors/create.ts
@@ -8,11 +8,9 @@ import { createModelFromFlags, REACTOR_FLAGS } from '../../reactors/utils';
 import {
   buildRuntime,
   isLegacyRuntimeImage,
-  promptRuntimeImage,
   promptRuntimeOptions,
   waitForResourceState,
 } from '../../runtime';
-import { promptStringIfUndefined } from '../../utils';
 
 export default class Create extends BaseCommand {
   public static description =
@@ -63,32 +61,18 @@ export default class Create extends BaseCommand {
       async: asyncFlag,
     } = flags;
 
-    const image = await promptRuntimeImage(flags.image);
+    const image = flags.image ?? '';
 
     validateReactorRuntimeFlags(flags as Record<string, unknown>, image);
     validateReactorApplicationId(applicationId, image);
 
-    const name = await promptStringIfUndefined(flags.name, {
-      message: 'What is the Reactor name?',
-      validate: (value) => Boolean(value),
-    });
+    const name = flags.name ?? '';
+    const code = flags['code'] ?? '';
+    const configuration = flags.configuration ?? '';
 
-    const code = await promptStringIfUndefined(flags['code'], {
-      message: 'Enter the Reactor code file path:',
-      validate: (value) => Boolean(value),
-    });
-
-    const configuration = await promptStringIfUndefined(flags.configuration, {
-      message: '(Optional) Enter the configuration file path (.env format):',
-    });
-
-    let promptedApplicationId: string | undefined;
-
-    if (isLegacyRuntimeImage(image)) {
-      promptedApplicationId = await promptStringIfUndefined(applicationId, {
-        message: '(Optional) Enter the Application ID to use in the Reactor:',
-      });
-    }
+    const promptedApplicationId = isLegacyRuntimeImage(image)
+      ? applicationId ?? ''
+      : undefined;
 
     let runtime;
 

--- a/src/commands/reactors/delete.ts
+++ b/src/commands/reactors/delete.ts
@@ -29,11 +29,10 @@ export default class Delete extends BaseCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { yes },
       args: { id },
     } = await this.parse(Delete);
 
-    if (await deleteReactor(bt, id, yes)) {
+    if (await deleteReactor(bt, id)) {
       this.log('Reactor deleted successfully!');
     }
   }

--- a/src/commands/reactors/get-result.ts
+++ b/src/commands/reactors/get-result.ts
@@ -1,0 +1,33 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class GetResult extends ApiCommand {
+  public static description =
+    'Gets the result of an asynchronous Reactor invocation';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> reactor-123 request-456',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Reactor ID',
+      required: true,
+    }),
+    'request-id': Args.string({
+      description: 'Async request ID',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id, 'request-id': requestId },
+    } = await this.parse(GetResult);
+
+    const result = await bt.reactors.results.get(id, requestId);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/reactors/index.ts
+++ b/src/commands/reactors/index.ts
@@ -1,8 +1,5 @@
-import select from '@inquirer/select';
-import { Flags } from '@oclif/core';
+import { Flags, ux } from '@oclif/core';
 import { BaseCommand } from '../../base';
-import { showReactorLogs } from '../../logs';
-import { deleteReactor, selectReactor } from '../../reactors/management';
 
 export default class Reactors extends BaseCommand {
   public static description =
@@ -16,55 +13,41 @@ export default class Reactors extends BaseCommand {
       description: 'Reactors list page to fetch',
       default: 1,
     }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
   };
-
-  public static args = {};
 
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { page },
+      flags: { page, size, json },
     } = await this.parse(Reactors);
 
-    const reactor = await selectReactor(bt, page);
-
-    if (!reactor) {
-      return undefined;
-    }
-
-    const action = await select({
-      message: 'Select action to perform',
-      choices: [
-        {
-          name: 'See details',
-          value: 'details',
-        },
-        {
-          name: 'Logs',
-          value: 'logs',
-          description: 'See Reactor real-time logs',
-        },
-        {
-          name: 'Delete',
-          value: 'delete',
-        },
-      ],
+    const reactors = await bt.reactors.list({
+      page,
+      size,
     });
 
-    if (action === 'details') {
-      this.logJson(reactor);
+    if (json) {
+      this.logJson(reactors);
 
-      return undefined;
+      return;
     }
 
-    if (action === 'logs') {
-      return showReactorLogs(bt, reactor.id ?? '');
+    if (!reactors.data.length) {
+      this.log('No reactors found.');
+
+      return;
     }
 
-    if (action === 'delete' && (await deleteReactor(bt, reactor.id ?? ''))) {
-      return this.log('Reactor deleted successfully!');
-    }
-
-    return undefined;
+    ux.table(reactors.data as unknown as Record<string, unknown>[], {
+      id: {},
+      name: {},
+      state: {},
+      createdAt: { header: 'Created At' },
+    });
   }
 }

--- a/src/commands/reactors/invoke-async.ts
+++ b/src/commands/reactors/invoke-async.ts
@@ -33,7 +33,10 @@ export default class InvokeAsync extends ApiCommand {
       flags: { data, file },
     } = await this.parse(InvokeAsync);
 
-    const body = readJsonInput({ data, file });
+    const body = readJsonInput({
+      data,
+      file,
+    });
 
     const result = await bt.reactors.reactAsync(
       id,

--- a/src/commands/reactors/invoke-async.ts
+++ b/src/commands/reactors/invoke-async.ts
@@ -1,0 +1,47 @@
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class InvokeAsync extends ApiCommand {
+  public static description = 'Invokes a Reactor asynchronously';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> reactor-123 --data \'{"key": "value"}\'',
+    '<%= config.bin %> <%= command.id %> reactor-123 --file ./request.json',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Reactor ID',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    data: Flags.string({
+      description: 'request body as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to a JSON file containing the request body',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { data, file },
+    } = await this.parse(InvokeAsync);
+
+    const body = readJsonInput({ data, file });
+
+    const result = await bt.reactors.reactAsync(
+      id,
+      body as Record<string, unknown> | undefined
+    );
+
+    this.log(
+      `Async reactor request submitted. Request ID: ${result.asyncReactorRequestId}`
+    );
+  }
+}

--- a/src/commands/reactors/invoke.ts
+++ b/src/commands/reactors/invoke.ts
@@ -1,0 +1,45 @@
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class Invoke extends ApiCommand {
+  public static description = 'Invokes a Reactor synchronously';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> reactor-123 --data \'{"key": "value"}\'',
+    '<%= config.bin %> <%= command.id %> reactor-123 --file ./request.json',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Reactor ID',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    data: Flags.string({
+      description: 'request body as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to a JSON file containing the request body',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { data, file },
+    } = await this.parse(Invoke);
+
+    const body = readJsonInput({ data, file });
+
+    const result = await bt.reactors.react(
+      id,
+      body as Record<string, unknown> | undefined
+    );
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/reactors/invoke.ts
+++ b/src/commands/reactors/invoke.ts
@@ -33,7 +33,10 @@ export default class Invoke extends ApiCommand {
       flags: { data, file },
     } = await this.parse(Invoke);
 
-    const body = readJsonInput({ data, file });
+    const body = readJsonInput({
+      data,
+      file,
+    });
 
     const result = await bt.reactors.react(
       id,

--- a/src/commands/reactors/logs.ts
+++ b/src/commands/reactors/logs.ts
@@ -1,14 +1,12 @@
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 import { DEFAULT_LOGS_SERVER_PORT, showReactorLogs } from '../../logs';
-import { selectReactor } from '../../reactors/management';
 
 export default class Logs extends BaseCommand {
   public static description =
     'Display live Reactor logs output. Requires `reactor:update` Management Application permissions';
 
   public static examples = [
-    '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca',
     '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca -p 3000',
   ];
@@ -16,6 +14,7 @@ export default class Logs extends BaseCommand {
   public static args = {
     id: Args.string({
       description: 'Reactor id to connect to',
+      required: true,
     }),
   };
 
@@ -34,16 +33,6 @@ export default class Logs extends BaseCommand {
       args: { id },
     } = await this.parse(Logs);
 
-    if (id) {
-      return showReactorLogs(bt, id, port);
-    }
-
-    const reactor = await selectReactor(bt, 1);
-
-    if (!reactor) {
-      return undefined;
-    }
-
-    return showReactorLogs(bt, reactor.id ?? '', port);
+    return showReactorLogs(bt, id, port);
   }
 }

--- a/src/commands/tenants/delete.ts
+++ b/src/commands/tenants/delete.ts
@@ -1,0 +1,36 @@
+import confirm from '@inquirer/confirm';
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Delete extends BaseCommand {
+  public static description = 'Delete the current tenant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Delete);
+
+    if (!flags.force) {
+      const proceed = await confirm({
+        message: 'Are you sure you want to delete this Tenant?',
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.tenants.self.delete();
+
+    this.log('Tenant deleted successfully!');
+  }
+}

--- a/src/commands/tenants/delete.ts
+++ b/src/commands/tenants/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
@@ -16,18 +15,7 @@ export default class Delete extends BaseCommand {
   };
 
   public async run(): Promise<void> {
-    const { bt, flags } = await this.parse(Delete);
-
-    if (!flags.force) {
-      const proceed = await confirm({
-        message: 'Are you sure you want to delete this Tenant?',
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
+    const { bt } = await this.parse(Delete);
 
     await bt.tenants.self.delete();
 

--- a/src/commands/tenants/get.ts
+++ b/src/commands/tenants/get.ts
@@ -1,0 +1,24 @@
+import { BaseCommand } from '../../base';
+
+export default class Get extends BaseCommand {
+  public static description = 'Get current tenant details';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {};
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Get);
+
+    const tenant = await bt.tenants.self.get();
+
+    if (flags.json) {
+      this.logJson(tenant);
+    } else {
+      this.log(`id: ${tenant.id}`);
+      this.log(`name: ${tenant.name}`);
+      this.log(`type: ${tenant.type}`);
+      this.log(`createdAt: ${tenant.createdAt}`);
+    }
+  }
+}

--- a/src/commands/tenants/invitations/create.ts
+++ b/src/commands/tenants/invitations/create.ts
@@ -1,0 +1,37 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Create extends BaseCommand {
+  public static description = 'Create a tenant invitation';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    email: Flags.string({
+      char: 'e',
+      description: 'email address to invite',
+      required: true,
+    }),
+    role: Flags.string({
+      char: 'r',
+      description: 'role for the invitation',
+      default: 'ADMIN',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const invitation = await bt.tenants.invitations.create({
+      email: flags.email,
+      role: flags.role,
+    });
+
+    this.log('Invitation created successfully!');
+    this.log(`id: ${invitation.id}`);
+
+    if (flags.json) {
+      this.logJson(invitation);
+    }
+  }
+}

--- a/src/commands/tenants/invitations/delete.ts
+++ b/src/commands/tenants/invitations/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base';
 
@@ -27,20 +26,8 @@ export default class Delete extends BaseCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { force },
       args: { id },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Invitation (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.tenants.invitations.delete(id);
 

--- a/src/commands/tenants/invitations/delete.ts
+++ b/src/commands/tenants/invitations/delete.ts
@@ -1,0 +1,49 @@
+import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Delete extends BaseCommand {
+  public static description = 'Delete a tenant invitation';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Invitation id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { force },
+      args: { id },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Invitation (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.tenants.invitations.delete(id);
+
+    this.log('Invitation deleted successfully!');
+  }
+}

--- a/src/commands/tenants/invitations/index.ts
+++ b/src/commands/tenants/invitations/index.ts
@@ -35,7 +35,7 @@ export default class Invitations extends BaseCommand {
 
     const invitations = result.data ?? [];
 
-    if (invitations.length === 0) {
+    if (!invitations.length) {
       this.log('No invitations found.');
 
       return;

--- a/src/commands/tenants/invitations/index.ts
+++ b/src/commands/tenants/invitations/index.ts
@@ -1,0 +1,61 @@
+import { Flags, ux } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Invitations extends BaseCommand {
+  public static description = 'List tenant invitations';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    page: Flags.integer({
+      char: 'p',
+      description: 'page number to fetch',
+      default: 1,
+    }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Invitations);
+
+    const result = await bt.tenants.invitations.list({
+      page: flags.page,
+      size: flags.size,
+    });
+
+    if (flags.json) {
+      this.logJson(result);
+
+      return;
+    }
+
+    const invitations = result.data ?? [];
+
+    if (invitations.length === 0) {
+      this.log('No invitations found.');
+
+      return;
+    }
+
+    ux.table(
+      invitations.map((inv) => ({
+        id: inv.id,
+        email: inv.email,
+        role: inv.role,
+        status: inv.status,
+        createdAt: inv.createdAt,
+      })),
+      {
+        id: {},
+        email: {},
+        role: {},
+        status: {},
+        createdAt: { header: 'Created At' },
+      }
+    );
+  }
+}

--- a/src/commands/tenants/invitations/resend.ts
+++ b/src/commands/tenants/invitations/resend.ts
@@ -1,0 +1,30 @@
+import { Args } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Resend extends BaseCommand {
+  public static description = 'Resend a tenant invitation';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Invitation id to resend',
+      required: true,
+    }),
+  };
+
+  public static flags = {};
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Resend);
+
+    await bt.tenants.invitations.resend(id);
+
+    this.log('Invitation resent successfully!');
+  }
+}

--- a/src/commands/tenants/members/delete.ts
+++ b/src/commands/tenants/members/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../../base';
 
@@ -27,20 +26,8 @@ export default class Delete extends BaseCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { force },
       args: { id },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Member (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.tenants.members.delete(id);
 

--- a/src/commands/tenants/members/delete.ts
+++ b/src/commands/tenants/members/delete.ts
@@ -1,0 +1,49 @@
+import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Delete extends BaseCommand {
+  public static description = 'Delete a tenant member';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> 03858bf5-32d3-4a2e-b74b-daeea0883bca',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Member id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { force },
+      args: { id },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Member (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.tenants.members.delete(id);
+
+    this.log('Member deleted successfully!');
+  }
+}

--- a/src/commands/tenants/members/index.ts
+++ b/src/commands/tenants/members/index.ts
@@ -39,7 +39,7 @@ export default class Members extends BaseCommand {
 
     const members = result.data ?? [];
 
-    if (members.length === 0) {
+    if (!members.length) {
       this.log('No members found.');
 
       return;

--- a/src/commands/tenants/members/index.ts
+++ b/src/commands/tenants/members/index.ts
@@ -1,0 +1,63 @@
+import { Flags, ux } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Members extends BaseCommand {
+  public static description = 'List tenant members';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    page: Flags.integer({
+      char: 'p',
+      description: 'page number to fetch',
+      default: 1,
+    }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
+    'user-id': Flags.string({
+      description: 'filter by user ID',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Members);
+
+    const result = await bt.tenants.members.list({
+      page: flags.page,
+      size: flags.size,
+      userId: flags['user-id'],
+    });
+
+    if (flags.json) {
+      this.logJson(result);
+
+      return;
+    }
+
+    const members = result.data ?? [];
+
+    if (members.length === 0) {
+      this.log('No members found.');
+
+      return;
+    }
+
+    ux.table(
+      members.map((m) => ({
+        id: m.id,
+        email: m.user?.email ?? '',
+        role: m.role,
+        createdAt: m.createdDate,
+      })),
+      {
+        id: {},
+        email: {},
+        role: {},
+        createdAt: { header: 'Created At' },
+      }
+    );
+  }
+}

--- a/src/commands/tenants/members/update.ts
+++ b/src/commands/tenants/members/update.ts
@@ -1,0 +1,39 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Update extends BaseCommand {
+  public static description = 'Update a tenant member';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Member id to update',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    role: Flags.string({
+      char: 'r',
+      description: 'role for the member (ADMIN, MEMBER)',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { role },
+    } = await this.parse(Update);
+
+    const member = await bt.tenants.members.update(id, { role });
+
+    this.log('Member updated successfully!');
+
+    if (this.jsonEnabled()) {
+      this.logJson(member);
+    }
+  }
+}

--- a/src/commands/tenants/merchants/index.ts
+++ b/src/commands/tenants/merchants/index.ts
@@ -40,7 +40,7 @@ export default class Merchants extends BaseCommand {
       this.error(`Request failed with status ${response.status}: ${errorBody}`);
     }
 
-    const result = await response.json() as any;
+    const result = (await response.json()) as any;
 
     if (flags.json) {
       this.logJson(result);
@@ -50,7 +50,7 @@ export default class Merchants extends BaseCommand {
 
     const merchants = result.data ?? [];
 
-    if (merchants.length === 0) {
+    if (!merchants.length) {
       this.log('No merchants found.');
 
       return;

--- a/src/commands/tenants/merchants/index.ts
+++ b/src/commands/tenants/merchants/index.ts
@@ -1,5 +1,6 @@
 import { Flags, ux } from '@oclif/core';
 import { BaseCommand } from '../../../base';
+import { loadConfig } from '../../../config';
 
 export default class Merchants extends BaseCommand {
   public static description = 'List tenant merchants';
@@ -20,13 +21,27 @@ export default class Merchants extends BaseCommand {
   };
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(Merchants);
+    const { bt, flags } = await this.parse(Merchants);
 
-    const apiKey = flags['management-key'];
-    const baseUrl = flags['api-base-url'] || 'https://api.basistheory.com';
+    const config = loadConfig();
+    const apiKey = flags['management-key'] || config.managementApiKey;
+
+    if (!apiKey) {
+      this.error(
+        '--management-key (BT_MANAGEMENT_KEY) must be provided via flag, environment variable, or ~/.basistheory/cli.json.'
+      );
+    }
+
+    const baseUrl =
+      flags['api-base-url'] ||
+      config.apiBaseUrl ||
+      'https://api.basistheory.com';
+
+    // Get the current tenant ID first, then list merchants
+    const tenant = await bt.tenants.self.get();
 
     const response = await fetch(
-      `${baseUrl}/tenants/self/merchants?page=${flags.page}&size=${flags.size}`,
+      `${baseUrl}/tenants/${tenant.id}/merchants?page=${flags.page}&size=${flags.size}`,
       {
         headers: {
           'BT-API-KEY': apiKey,

--- a/src/commands/tenants/merchants/index.ts
+++ b/src/commands/tenants/merchants/index.ts
@@ -55,7 +55,9 @@ export default class Merchants extends BaseCommand {
       this.error(`Request failed with status ${response.status}: ${errorBody}`);
     }
 
-    const result = (await response.json()) as any;
+    const result = (await response.json()) as {
+      data?: Record<string, unknown>[];
+    };
 
     if (flags.json) {
       this.logJson(result);
@@ -72,7 +74,7 @@ export default class Merchants extends BaseCommand {
     }
 
     ux.table(
-      merchants.map((m: any) => ({
+      merchants.map((m: Record<string, unknown>) => ({
         id: m.id,
         name: m.name,
         createdAt: m.createdAt,

--- a/src/commands/tenants/merchants/index.ts
+++ b/src/commands/tenants/merchants/index.ts
@@ -1,0 +1,57 @@
+import { Flags, ux } from '@oclif/core';
+import { BaseCommand } from '../../../base';
+
+export default class Merchants extends BaseCommand {
+  public static description = 'List tenant merchants';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    page: Flags.integer({
+      char: 'p',
+      description: 'page number to fetch',
+      default: 1,
+    }),
+    size: Flags.integer({
+      char: 's',
+      description: 'number of items per page',
+      default: 20,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Merchants);
+
+    const result = await (bt.tenants as any).merchants.list({
+      page: flags.page,
+      size: flags.size,
+    });
+
+    if (flags.json) {
+      this.logJson(result);
+
+      return;
+    }
+
+    const merchants = result.data ?? [];
+
+    if (merchants.length === 0) {
+      this.log('No merchants found.');
+
+      return;
+    }
+
+    ux.table(
+      merchants.map((m: any) => ({
+        id: m.id,
+        name: m.name,
+        createdAt: m.createdAt,
+      })),
+      {
+        id: {},
+        name: {},
+        createdAt: { header: 'Created At' },
+      }
+    );
+  }
+}

--- a/src/commands/tenants/merchants/index.ts
+++ b/src/commands/tenants/merchants/index.ts
@@ -20,12 +20,27 @@ export default class Merchants extends BaseCommand {
   };
 
   public async run(): Promise<void> {
-    const { bt, flags } = await this.parse(Merchants);
+    const { flags } = await this.parse(Merchants);
 
-    const result = await (bt.tenants as any).merchants.list({
-      page: flags.page,
-      size: flags.size,
-    });
+    const apiKey = flags['management-key'];
+    const baseUrl = flags['api-base-url'] || 'https://api.basistheory.com';
+
+    const response = await fetch(
+      `${baseUrl}/tenants/self/merchants?page=${flags.page}&size=${flags.size}`,
+      {
+        headers: {
+          'BT-API-KEY': apiKey,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+
+      this.error(`Request failed with status ${response.status}: ${errorBody}`);
+    }
+
+    const result = await response.json() as any;
 
     if (flags.json) {
       this.logJson(result);

--- a/src/commands/tenants/update.ts
+++ b/src/commands/tenants/update.ts
@@ -1,0 +1,53 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Update extends BaseCommand {
+  public static description = 'Update the current tenant';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    name: Flags.string({
+      char: 'n',
+      description: 'name of the Tenant',
+    }),
+    'fingerprint-tokens': Flags.string({
+      description: 'enable or disable token fingerprinting',
+    }),
+    'deduplicate-tokens': Flags.string({
+      description: 'enable or disable token deduplication',
+    }),
+    'disable-ephemeral-proxy': Flags.string({
+      description: 'enable or disable ephemeral proxy',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Update);
+
+    const settings: Record<string, string | undefined> = {};
+
+    if (flags['fingerprint-tokens'] !== undefined) {
+      settings.fingerprintTokens = flags['fingerprint-tokens'];
+    }
+
+    if (flags['deduplicate-tokens'] !== undefined) {
+      settings.deduplicateTokens = flags['deduplicate-tokens'];
+    }
+
+    if (flags['disable-ephemeral-proxy'] !== undefined) {
+      settings.disableEphemeralProxy = flags['disable-ephemeral-proxy'];
+    }
+
+    const tenant = await bt.tenants.self.update({
+      name: flags.name || '',
+      settings: Object.keys(settings).length > 0 ? settings : undefined,
+    });
+
+    this.log('Tenant updated successfully!');
+
+    if (flags.json) {
+      this.logJson(tenant);
+    }
+  }
+}

--- a/src/commands/tenants/update.ts
+++ b/src/commands/tenants/update.ts
@@ -41,7 +41,7 @@ export default class Update extends BaseCommand {
 
     const tenant = await bt.tenants.self.update({
       name: flags.name || '',
-      settings: Object.keys(settings).length > 0 ? settings : undefined,
+      settings: Object.keys(settings).length ? settings : undefined,
     });
 
     this.log('Tenant updated successfully!');

--- a/src/commands/tenants/usage.ts
+++ b/src/commands/tenants/usage.ts
@@ -1,0 +1,17 @@
+import { BaseCommand } from '../../base';
+
+export default class Usage extends BaseCommand {
+  public static description = 'Get tenant usage report';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {};
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Usage);
+
+    const report = await bt.tenants.self.getUsageReports();
+
+    this.logJson(report);
+  }
+}

--- a/src/commands/token-intents/create.ts
+++ b/src/commands/token-intents/create.ts
@@ -1,0 +1,37 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { requireJsonInput } from '../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a new token intent';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --type card --data \'{"number":"4242424242424242"}\'',
+  ];
+
+  public static flags = {
+    type: Flags.string({
+      description: 'token intent type',
+      required: true,
+    }),
+    data: Flags.string({
+      description: 'token intent data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing token intent data',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const data = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const tokenIntent = await bt.tokenIntents.create({
+      type: flags.type,
+      data,
+    });
+
+    this.logJson(tokenIntent);
+  }
+}

--- a/src/commands/token-intents/create.ts
+++ b/src/commands/token-intents/create.ts
@@ -25,7 +25,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const data = requireJsonInput({ data: flags.data, file: flags.file });
+    const data = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const tokenIntent = await bt.tokenIntents.create({
       type: flags.type,

--- a/src/commands/token-intents/delete.ts
+++ b/src/commands/token-intents/delete.ts
@@ -1,0 +1,48 @@
+import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete a token intent';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> ti-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Token intent id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { force },
+      args: { id },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const confirmed = await confirm({
+        message: `Are you sure you want to delete token intent ${id}?`,
+      });
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    await bt.tokenIntents.delete(id);
+
+    this.log('Token intent deleted successfully!');
+  }
+}

--- a/src/commands/token-intents/delete.ts
+++ b/src/commands/token-intents/delete.ts
@@ -5,9 +5,7 @@ import { ApiCommand } from '../../api-command';
 export default class Delete extends ApiCommand {
   public static description = 'Delete a token intent';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> ti-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> ti-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/token-intents/delete.ts
+++ b/src/commands/token-intents/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -25,19 +24,8 @@ export default class Delete extends ApiCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { force },
       args: { id },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const confirmed = await confirm({
-        message: `Are you sure you want to delete token intent ${id}?`,
-      });
-
-      if (!confirmed) {
-        return;
-      }
-    }
 
     await bt.tokenIntents.delete(id);
 

--- a/src/commands/token-intents/get.ts
+++ b/src/commands/token-intents/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a token intent by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> ti-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Token intent id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const tokenIntent = await bt.tokenIntents.get(id);
+
+    this.logJson(tokenIntent);
+  }
+}

--- a/src/commands/tokenize.ts
+++ b/src/commands/tokenize.ts
@@ -21,7 +21,10 @@ export default class Tokenize extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Tokenize);
 
-    const input = requireJsonInput({ data: flags.data, file: flags.file });
+    const input = requireJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const result = await bt.tokens.tokenize(input);
 

--- a/src/commands/tokenize.ts
+++ b/src/commands/tokenize.ts
@@ -1,0 +1,30 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../api-command';
+import { requireJsonInput } from '../json-input';
+
+export default class Tokenize extends ApiCommand {
+  public static description = 'Tokenize data';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --data \'{"type":"token","data":"secret"}\'',
+  ];
+
+  public static flags = {
+    data: Flags.string({
+      description: 'JSON data to tokenize',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing data to tokenize',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Tokenize);
+
+    const input = requireJsonInput({ data: flags.data, file: flags.file });
+
+    const result = await bt.tokens.tokenize(input);
+
+    this.logJson(result);
+  }
+}

--- a/src/commands/tokens/create.ts
+++ b/src/commands/tokens/create.ts
@@ -44,7 +44,10 @@ export default class Create extends ApiCommand {
   public async run(): Promise<void> {
     const { bt, flags } = await this.parse(Create);
 
-    const data = readJsonInput({ data: flags.data, file: flags.file });
+    const data = readJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const metadata: Record<string, string> | undefined = flags.metadata?.length
       ? Object.fromEntries(

--- a/src/commands/tokens/create.ts
+++ b/src/commands/tokens/create.ts
@@ -1,0 +1,72 @@
+import { Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class Create extends ApiCommand {
+  public static description = 'Create a new token';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --type token --data \'{"key":"value"}\'',
+  ];
+
+  public static flags = {
+    type: Flags.string({
+      description: 'token type',
+    }),
+    data: Flags.string({
+      description: 'token data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing token data',
+    }),
+    'token-intent-id': Flags.string({
+      description: 'token intent ID to use',
+    }),
+    container: Flags.string({
+      description: 'container for the token',
+      multiple: true,
+    }),
+    metadata: Flags.string({
+      description: 'metadata key=value pair',
+      multiple: true,
+    }),
+    'expires-at': Flags.string({
+      description: 'token expiration date',
+    }),
+    'fingerprint-expression': Flags.string({
+      description: 'fingerprint expression',
+    }),
+    deduplicate: Flags.boolean({
+      description: 'enable token deduplication',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { bt, flags } = await this.parse(Create);
+
+    const data = readJsonInput({ data: flags.data, file: flags.file });
+
+    const metadata: Record<string, string> | undefined = flags.metadata?.length
+      ? Object.fromEntries(
+          flags.metadata.map((m) => {
+            const [key, ...rest] = m.split('=');
+
+            return [key, rest.join('=')];
+          })
+        )
+      : undefined;
+
+    const token = await bt.tokens.create({
+      type: flags.type,
+      data,
+      tokenIntentId: flags['token-intent-id'],
+      containers: flags.container,
+      metadata,
+      expiresAt: flags['expires-at'],
+      fingerprintExpression: flags['fingerprint-expression'],
+      deduplicateToken: flags.deduplicate,
+    });
+
+    this.logJson(token);
+  }
+}

--- a/src/commands/tokens/delete.ts
+++ b/src/commands/tokens/delete.ts
@@ -5,9 +5,7 @@ import { ApiCommand } from '../../api-command';
 export default class Delete extends ApiCommand {
   public static description = 'Delete a token';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> tok-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> tok-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/tokens/delete.ts
+++ b/src/commands/tokens/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
@@ -25,19 +24,8 @@ export default class Delete extends ApiCommand {
   public async run(): Promise<void> {
     const {
       bt,
-      flags: { force },
       args: { id },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const confirmed = await confirm({
-        message: `Are you sure you want to delete token ${id}?`,
-      });
-
-      if (!confirmed) {
-        return;
-      }
-    }
 
     await bt.tokens.delete(id);
 

--- a/src/commands/tokens/delete.ts
+++ b/src/commands/tokens/delete.ts
@@ -1,0 +1,48 @@
+import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Delete extends ApiCommand {
+  public static description = 'Delete a token';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> tok-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Token id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { force },
+      args: { id },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const confirmed = await confirm({
+        message: `Are you sure you want to delete token ${id}?`,
+      });
+
+      if (!confirmed) {
+        return;
+      }
+    }
+
+    await bt.tokens.delete(id);
+
+    this.log('Token deleted successfully!');
+  }
+}

--- a/src/commands/tokens/get.ts
+++ b/src/commands/tokens/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Get extends ApiCommand {
+  public static description = 'Get a token by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> tok-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Token id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const token = await bt.tokens.get(id);
+
+    this.logJson(token);
+  }
+}

--- a/src/commands/tokens/index.ts
+++ b/src/commands/tokens/index.ts
@@ -1,0 +1,53 @@
+import { Flags, ux } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Tokens extends ApiCommand {
+  public static description = 'List tokens';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    container: Flags.string({
+      description: 'filter by container',
+    }),
+    type: Flags.string({
+      description: 'filter by token type',
+    }),
+    fingerprint: Flags.string({
+      description: 'filter by fingerprint',
+    }),
+    size: Flags.integer({
+      description: 'number of tokens to return',
+      default: 20,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { container, type, fingerprint, size },
+    } = await this.parse(Tokens);
+
+    const result = await bt.tokens.listV2({
+      container,
+      type,
+      fingerprint,
+      size,
+    });
+
+    if (!result.data?.length) {
+      this.log('No tokens found.');
+
+      return;
+    }
+
+    ux.table(result.data as unknown as Record<string, unknown>[], {
+      id: {},
+      type: {},
+      containers: {
+        get: (row) => ((row.containers as string[]) ?? []).join(', '),
+      },
+      createdAt: { header: 'created_at' },
+    });
+  }
+}

--- a/src/commands/tokens/search.ts
+++ b/src/commands/tokens/search.ts
@@ -1,0 +1,45 @@
+import { Flags, ux } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+export default class Search extends ApiCommand {
+  public static description = 'Search tokens';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> --query \'data:4242\'',
+  ];
+
+  public static flags = {
+    query: Flags.string({
+      description: 'search query',
+      required: true,
+    }),
+    size: Flags.integer({
+      description: 'number of tokens to return',
+      default: 20,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { query, size },
+    } = await this.parse(Search);
+
+    const result = await bt.tokens.searchV2({ query, size });
+
+    if (!result.data?.length) {
+      this.log('No tokens found.');
+
+      return;
+    }
+
+    ux.table(result.data as unknown as Record<string, unknown>[], {
+      id: {},
+      type: {},
+      containers: {
+        get: (row) => ((row.containers as string[]) ?? []).join(', '),
+      },
+      createdAt: { header: 'created_at' },
+    });
+  }
+}

--- a/src/commands/tokens/search.ts
+++ b/src/commands/tokens/search.ts
@@ -5,7 +5,7 @@ export default class Search extends ApiCommand {
   public static description = 'Search tokens';
 
   public static examples = [
-    '<%= config.bin %> <%= command.id %> --query \'data:4242\'',
+    "<%= config.bin %> <%= command.id %> --query 'data:4242'",
   ];
 
   public static flags = {
@@ -25,7 +25,10 @@ export default class Search extends ApiCommand {
       flags: { query, size },
     } = await this.parse(Search);
 
-    const result = await bt.tokens.searchV2({ query, size });
+    const result = await bt.tokens.searchV2({
+      query,
+      size,
+    });
 
     if (!result.data?.length) {
       this.log('No tokens found.');

--- a/src/commands/tokens/types.ts
+++ b/src/commands/tokens/types.ts
@@ -1,0 +1,29 @@
+import { ux } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+
+const TOKEN_TYPES = [
+  { type: 'token', defaultContainer: '/general/high/' },
+  { type: 'card', defaultContainer: '/pci/high/' },
+  { type: 'network_token', defaultContainer: '/pci/high/' },
+  { type: 'bank', defaultContainer: '/bank/high/' },
+  { type: 'card_number', defaultContainer: '/pci/high/' },
+  { type: 'us_bank_account_number', defaultContainer: '/bank/high/' },
+  { type: 'us_bank_routing_number', defaultContainer: '/bank/low/' },
+  { type: 'social_security_number', defaultContainer: '/pii/high/' },
+  { type: 'employer_id_number', defaultContainer: '/pii/high/' },
+];
+
+export default class Types extends ApiCommand {
+  public static description = 'List available token types';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    await this.parse(Types);
+
+    ux.table(TOKEN_TYPES, {
+      type: {},
+      defaultContainer: { header: 'default_container' },
+    });
+  }
+}

--- a/src/commands/tokens/types.ts
+++ b/src/commands/tokens/types.ts
@@ -2,15 +2,42 @@ import { ux } from '@oclif/core';
 import { ApiCommand } from '../../api-command';
 
 const TOKEN_TYPES = [
-  { type: 'token', defaultContainer: '/general/high/' },
-  { type: 'card', defaultContainer: '/pci/high/' },
-  { type: 'network_token', defaultContainer: '/pci/high/' },
-  { type: 'bank', defaultContainer: '/bank/high/' },
-  { type: 'card_number', defaultContainer: '/pci/high/' },
-  { type: 'us_bank_account_number', defaultContainer: '/bank/high/' },
-  { type: 'us_bank_routing_number', defaultContainer: '/bank/low/' },
-  { type: 'social_security_number', defaultContainer: '/pii/high/' },
-  { type: 'employer_id_number', defaultContainer: '/pii/high/' },
+  {
+    type: 'token',
+    defaultContainer: '/general/high/',
+  },
+  {
+    type: 'card',
+    defaultContainer: '/pci/high/',
+  },
+  {
+    type: 'network_token',
+    defaultContainer: '/pci/high/',
+  },
+  {
+    type: 'bank',
+    defaultContainer: '/bank/high/',
+  },
+  {
+    type: 'card_number',
+    defaultContainer: '/pci/high/',
+  },
+  {
+    type: 'us_bank_account_number',
+    defaultContainer: '/bank/high/',
+  },
+  {
+    type: 'us_bank_routing_number',
+    defaultContainer: '/bank/low/',
+  },
+  {
+    type: 'social_security_number',
+    defaultContainer: '/pii/high/',
+  },
+  {
+    type: 'employer_id_number',
+    defaultContainer: '/pii/high/',
+  },
 ];
 
 export default class Types extends ApiCommand {

--- a/src/commands/tokens/update.ts
+++ b/src/commands/tokens/update.ts
@@ -49,7 +49,10 @@ export default class Update extends ApiCommand {
       flags,
     } = await this.parse(Update);
 
-    const data = readJsonInput({ data: flags.data, file: flags.file });
+    const data = readJsonInput({
+      data: flags.data,
+      file: flags.file,
+    });
 
     const metadata: Record<string, string> | undefined = flags.metadata?.length
       ? Object.fromEntries(

--- a/src/commands/tokens/update.ts
+++ b/src/commands/tokens/update.ts
@@ -1,0 +1,75 @@
+import { Args, Flags } from '@oclif/core';
+import { ApiCommand } from '../../api-command';
+import { readJsonInput } from '../../json-input';
+
+export default class Update extends ApiCommand {
+  public static description = 'Update an existing token';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> tok-123 --data \'{"key":"new-value"}\'',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Token id to update',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    data: Flags.string({
+      description: 'token data as JSON string',
+    }),
+    file: Flags.string({
+      description: 'path to JSON file containing token data',
+    }),
+    container: Flags.string({
+      description: 'container for the token',
+      multiple: true,
+    }),
+    metadata: Flags.string({
+      description: 'metadata key=value pair',
+      multiple: true,
+    }),
+    'expires-at': Flags.string({
+      description: 'token expiration date',
+    }),
+    'fingerprint-expression': Flags.string({
+      description: 'fingerprint expression',
+    }),
+    deduplicate: Flags.boolean({
+      description: 'enable token deduplication',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags,
+    } = await this.parse(Update);
+
+    const data = readJsonInput({ data: flags.data, file: flags.file });
+
+    const metadata: Record<string, string> | undefined = flags.metadata?.length
+      ? Object.fromEntries(
+          flags.metadata.map((m) => {
+            const [key, ...rest] = m.split('=');
+
+            return [key, rest.join('=')];
+          })
+        )
+      : undefined;
+
+    const token = await bt.tokens.update(id, {
+      data,
+      containers: flags.container,
+      metadata,
+      expiresAt: flags['expires-at'],
+      fingerprintExpression: flags['fingerprint-expression'],
+      deduplicateToken: flags.deduplicate,
+    });
+
+    this.logJson(token);
+  }
+}

--- a/src/commands/webhooks/create.ts
+++ b/src/commands/webhooks/create.ts
@@ -1,0 +1,44 @@
+import { Flags } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Create extends BaseCommand {
+  public static description = 'Create a new webhook';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public static flags = {
+    name: Flags.string({
+      description: 'name of the webhook',
+      required: true,
+    }),
+    url: Flags.string({
+      description: 'URL of the webhook',
+      required: true,
+    }),
+    events: Flags.string({
+      description: 'events to subscribe to',
+      multiple: true,
+      required: true,
+    }),
+    'notify-email': Flags.string({
+      description: 'email to notify on webhook failure',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      flags: { name, url, events, 'notify-email': notifyEmail },
+    } = await this.parse(Create);
+
+    const webhook = await bt.webhooks.create({
+      name,
+      url,
+      events,
+      notifyEmail,
+    });
+
+    this.log('Webhook created successfully!');
+    this.logJson(webhook);
+  }
+}

--- a/src/commands/webhooks/delete.ts
+++ b/src/commands/webhooks/delete.ts
@@ -1,0 +1,49 @@
+import { Args, Flags } from '@oclif/core';
+import confirm from '@inquirer/confirm';
+import { BaseCommand } from '../../base';
+
+export default class Delete extends BaseCommand {
+  public static description = 'Delete a webhook';
+
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> wh-123',
+  ];
+
+  public static args = {
+    id: Args.string({
+      description: 'Webhook id to delete',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'force deletion without confirmation',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { force },
+    } = await this.parse(Delete);
+
+    if (!force) {
+      const proceed = await confirm({
+        message: `Are you sure you want to delete this Webhook (${id})?`,
+        default: false,
+      });
+
+      if (!proceed) {
+        return;
+      }
+    }
+
+    await bt.webhooks.delete(id);
+
+    this.log('Webhook deleted successfully!');
+  }
+}

--- a/src/commands/webhooks/delete.ts
+++ b/src/commands/webhooks/delete.ts
@@ -1,4 +1,3 @@
-import confirm from '@inquirer/confirm';
 import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
@@ -26,19 +25,7 @@ export default class Delete extends BaseCommand {
     const {
       bt,
       args: { id },
-      flags: { force },
     } = await this.parse(Delete);
-
-    if (!force) {
-      const proceed = await confirm({
-        message: `Are you sure you want to delete this Webhook (${id})?`,
-        default: false,
-      });
-
-      if (!proceed) {
-        return;
-      }
-    }
 
     await bt.webhooks.delete(id);
 

--- a/src/commands/webhooks/delete.ts
+++ b/src/commands/webhooks/delete.ts
@@ -1,13 +1,11 @@
-import { Args, Flags } from '@oclif/core';
 import confirm from '@inquirer/confirm';
+import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../../base';
 
 export default class Delete extends BaseCommand {
   public static description = 'Delete a webhook';
 
-  public static examples = [
-    '<%= config.bin %> <%= command.id %> wh-123',
-  ];
+  public static examples = ['<%= config.bin %> <%= command.id %> wh-123'];
 
   public static args = {
     id: Args.string({

--- a/src/commands/webhooks/events.ts
+++ b/src/commands/webhooks/events.ts
@@ -1,0 +1,17 @@
+import { BaseCommand } from '../../base';
+
+export default class Events extends BaseCommand {
+  public static description = 'List available webhook event types';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Events);
+
+    const events = await bt.webhooks.events.list();
+
+    for (const event of events) {
+      this.log(event);
+    }
+  }
+}

--- a/src/commands/webhooks/get.ts
+++ b/src/commands/webhooks/get.ts
@@ -1,0 +1,26 @@
+import { Args } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Get extends BaseCommand {
+  public static description = 'Get a webhook by ID';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> wh-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Webhook id to retrieve',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+    } = await this.parse(Get);
+
+    const webhook = await bt.webhooks.get(id);
+
+    this.logJson(webhook);
+  }
+}

--- a/src/commands/webhooks/index.ts
+++ b/src/commands/webhooks/index.ts
@@ -1,0 +1,27 @@
+import { ux } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Webhooks extends BaseCommand {
+  public static description = 'List webhooks';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Webhooks);
+
+    const webhooks = await bt.webhooks.list();
+
+    if (!webhooks.data?.length) {
+      this.log('No webhooks found.');
+
+      return;
+    }
+
+    ux.table(webhooks.data as unknown as Record<string, unknown>[], {
+      id: {},
+      name: {},
+      url: {},
+      status: {},
+    });
+  }
+}

--- a/src/commands/webhooks/ping.ts
+++ b/src/commands/webhooks/ping.ts
@@ -1,0 +1,15 @@
+import { BaseCommand } from '../../base';
+
+export default class Ping extends BaseCommand {
+  public static description = 'Send a test ping to all webhooks';
+
+  public static examples = ['<%= config.bin %> <%= command.id %>'];
+
+  public async run(): Promise<void> {
+    const { bt } = await this.parse(Ping);
+
+    await bt.webhooks.ping();
+
+    this.log('Webhook ping sent successfully!');
+  }
+}

--- a/src/commands/webhooks/update.ts
+++ b/src/commands/webhooks/update.ts
@@ -1,0 +1,51 @@
+import { Args, Flags } from '@oclif/core';
+import { BaseCommand } from '../../base';
+
+export default class Update extends BaseCommand {
+  public static description = 'Update a webhook';
+
+  public static examples = ['<%= config.bin %> <%= command.id %> wh-123'];
+
+  public static args = {
+    id: Args.string({
+      description: 'Webhook id to update',
+      required: true,
+    }),
+  };
+
+  public static flags = {
+    name: Flags.string({
+      description: 'name of the webhook',
+    }),
+    url: Flags.string({
+      description: 'URL of the webhook',
+    }),
+    events: Flags.string({
+      description: 'events to subscribe to',
+      multiple: true,
+    }),
+    'notify-email': Flags.string({
+      description: 'email to notify on webhook failure',
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const {
+      bt,
+      args: { id },
+      flags: { name, url, events, 'notify-email': notifyEmail },
+    } = await this.parse(Update);
+
+    const existing = await bt.webhooks.get(id);
+
+    const webhook = await bt.webhooks.update(id, {
+      name: name || existing.name || '',
+      url: url || existing.url || '',
+      events: events || existing.events || [],
+      notifyEmail,
+    });
+
+    this.log('Webhook updated successfully!');
+    this.logJson(webhook);
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,43 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+interface CliConfig {
+  apiKey?: string;
+  managementApiKey?: string;
+  apiBaseUrl?: string;
+}
+
+const CONFIG_DIR = join(homedir(), '.basistheory');
+const CONFIG_PATH = join(CONFIG_DIR, 'cli.json');
+
+const DEFAULT_CONFIG: CliConfig = {};
+
+const ensureConfigFile = (): void => {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+
+  if (!existsSync(CONFIG_PATH)) {
+    writeFileSync(
+      CONFIG_PATH,
+      `${JSON.stringify(DEFAULT_CONFIG, undefined, 2)}\n`
+    );
+  }
+};
+
+const loadConfig = (): CliConfig => {
+  try {
+    if (!existsSync(CONFIG_PATH)) {
+      return {};
+    }
+
+    const contents = readFileSync(CONFIG_PATH, 'utf-8');
+
+    return JSON.parse(contents) as CliConfig;
+  } catch {
+    return {};
+  }
+};
+
+export { CliConfig, ensureConfigFile, loadConfig };

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -1,0 +1,9 @@
+import type { Hook } from '@oclif/core';
+import { ensureConfigFile } from '../config';
+
+// eslint-disable-next-line require-await
+const hook: Hook<'init'> = async () => {
+  ensureConfigFile();
+};
+
+export default hook;

--- a/src/json-input.ts
+++ b/src/json-input.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+interface JsonInputFlags {
+  data?: string;
+  file?: string;
+}
+
+const readJsonInput = (flags: JsonInputFlags): unknown => {
+  if (flags.data) {
+    try {
+      return JSON.parse(flags.data);
+    } catch {
+      throw new Error(
+        'Invalid JSON provided via --data flag. Please provide valid JSON.'
+      );
+    }
+  }
+
+  if (flags.file) {
+    const filePath = resolve(process.cwd(), flags.file);
+
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+
+      return JSON.parse(content);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`File not found: ${filePath}`);
+      }
+
+      throw new Error(
+        `Failed to parse JSON from file ${filePath}: ${
+          (error as Error).message
+        }`
+      );
+    }
+  }
+
+  return undefined;
+};
+
+const requireJsonInput = (flags: JsonInputFlags): unknown => {
+  const result = readJsonInput(flags);
+
+  if (result === undefined) {
+    throw new Error('Either --data or --file must be provided.');
+  }
+
+  return result;
+};
+
+export { readJsonInput, requireJsonInput, JsonInputFlags };

--- a/src/proxies/management.ts
+++ b/src/proxies/management.ts
@@ -1,96 +1,6 @@
 import type { BasisTheory, BasisTheoryClient } from '@basis-theory/node-sdk';
-import confirm from '@inquirer/confirm';
-import { ux } from '@oclif/core';
-import type { TableRow } from '../types';
-import { selectOrNavigate, PaginatedList } from '../utils';
 
 const debug = require('debug')('proxies:management');
-
-const listProxies = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<PaginatedList<BasisTheory.Proxy>> => {
-  const size = 5;
-
-  debug('Listing proxies', `page: ${page}`, `size: ${size}`);
-
-  const proxiesPage = await bt.proxies.list({
-    size,
-    page,
-  });
-
-  let data: TableRow<BasisTheory.Proxy>[] = [];
-
-  if (proxiesPage.data.length) {
-    const last = (page - 1) * size;
-
-    data = proxiesPage.data.map((proxy, index) => ({
-      '#': last + (index + 1),
-      ...proxy,
-    }));
-
-    ux.table(data, {
-      '#': {},
-      id: {},
-      name: {},
-      key: {},
-      state: {},
-      /* eslint-disable camelcase */
-      destination_url: {
-        header: 'Destination URL',
-        get: (proxy) => proxy.destinationUrl,
-      },
-      require_auth: {
-        header: 'Require Auth',
-        get: (proxy) => (proxy.requireAuth ? 'yes' : 'no'),
-      },
-      request_transform: {
-        header: 'Request Transform',
-        get: (proxy) => (proxy.requestTransform?.code ? 'yes' : 'no'),
-      },
-      response_transform: {
-        header: 'Response Transform',
-        get: (proxy) => (proxy.responseTransform?.code ? 'yes' : 'no'),
-      },
-      application_id: {
-        header: 'Application Id',
-        get: (proxy) => proxy.applicationId || '',
-      },
-      /* eslint-enable camelcase */
-    });
-  } else {
-    ux.log('No proxies found.');
-  }
-
-  return {
-    data,
-    page,
-    hasNextPage: proxiesPage.hasNextPage(),
-  };
-};
-
-const selectProxy = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<BasisTheory.Proxy | undefined> => {
-  const proxies = await listProxies(bt, page);
-
-  if (!proxies.data.length) {
-    return undefined;
-  }
-
-  const selection = await selectOrNavigate(proxies, '#');
-
-  if (selection === 'previous') {
-    return selectProxy(bt, page - 1);
-  }
-
-  if (selection === 'next') {
-    return selectProxy(bt, page + 1);
-  }
-
-  return selection;
-};
 
 const createProxy = (
   bt: BasisTheoryClient,
@@ -103,20 +13,8 @@ const createProxy = (
 
 const deleteProxy = async (
   bt: BasisTheoryClient,
-  id: string,
-  force = false
+  id: string
 ): Promise<boolean> => {
-  if (!force) {
-    const proceed = await confirm({
-      message: `Are you sure you want to delete this Proxy (${id})?`,
-      default: false,
-    });
-
-    if (!proceed) {
-      return false;
-    }
-  }
-
   debug(`Deleting Proxy`, id);
 
   await bt.proxies.delete(id);
@@ -143,4 +41,4 @@ const getProxy = (
   return bt.proxies.get(id);
 };
 
-export { selectProxy, createProxy, patchProxy, deleteProxy, getProxy };
+export { createProxy, patchProxy, deleteProxy, getProxy };

--- a/src/proxies/runtime.ts
+++ b/src/proxies/runtime.ts
@@ -107,13 +107,7 @@ const promptTransformRuntime = async (
       | undefined,
   };
 
-  const labelPrefix = `${prefix.charAt(0).toUpperCase()}${prefix.slice(
-    1
-  )} transform`;
-  const runtimeOptions = await promptRuntimeOptions(
-    transformFlags,
-    labelPrefix
-  );
+  const runtimeOptions = await promptRuntimeOptions(transformFlags);
 
   return buildRuntime({
     image,

--- a/src/reactors/management.ts
+++ b/src/reactors/management.ts
@@ -1,73 +1,6 @@
 import type { BasisTheory, BasisTheoryClient } from '@basis-theory/node-sdk';
-import confirm from '@inquirer/confirm';
-import { ux } from '@oclif/core';
-import type { TableRow } from '../types';
-import { selectOrNavigate, PaginatedList } from '../utils';
 
 const debug = require('debug')('reactors:management');
-
-const listReactors = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<PaginatedList<BasisTheory.Reactor>> => {
-  const size = 5;
-
-  debug('Listing reactors', `page: ${page}`, `size: ${size}`);
-
-  const reactorsPage = await bt.reactors.list({
-    size,
-    page,
-  });
-
-  let data: TableRow<BasisTheory.Reactor>[] = [];
-
-  if (reactorsPage.data.length) {
-    const last = (page - 1) * size;
-
-    data = reactorsPage.data.map((reactor, index) => ({
-      '#': last + (index + 1),
-      ...reactor,
-    }));
-
-    ux.table(data, {
-      '#': {},
-      id: {},
-      name: {},
-      state: {},
-    });
-  } else {
-    ux.log('No reactors found.');
-  }
-
-  return {
-    data,
-    page,
-    hasNextPage: reactorsPage.hasNextPage(),
-  };
-};
-
-const selectReactor = async (
-  bt: BasisTheoryClient,
-  page: number
-): Promise<BasisTheory.Reactor | undefined> => {
-  const reactors = await listReactors(bt, page);
-
-  if (!reactors.data.length) {
-    return undefined;
-  }
-
-  const selection = await selectOrNavigate(reactors, '#');
-
-  if (selection === 'previous') {
-    return selectReactor(bt, page - 1);
-  }
-
-  if (selection === 'next') {
-    return selectReactor(bt, page + 1);
-  }
-
-  return selection;
-};
 
 const createReactor = (
   bt: BasisTheoryClient,
@@ -80,20 +13,8 @@ const createReactor = (
 
 const deleteReactor = async (
   bt: BasisTheoryClient,
-  id: string,
-  force = false
+  id: string
 ): Promise<boolean> => {
-  if (!force) {
-    const proceed = await confirm({
-      message: `Are you sure you want to delete this Reactor (${id})?`,
-      default: false,
-    });
-
-    if (!proceed) {
-      return false;
-    }
-  }
-
   debug(`Deleting Reactor`, id);
 
   await bt.reactors.delete(id);
@@ -120,10 +41,4 @@ const getReactor = (
   return bt.reactors.get(id);
 };
 
-export {
-  selectReactor,
-  createReactor,
-  patchReactor,
-  deleteReactor,
-  getReactor,
-};
+export { createReactor, patchReactor, deleteReactor, getReactor };

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -28,7 +28,10 @@ const formatErrorMessage = (
   resource: BasisTheory.Reactor | BasisTheory.Proxy,
   resourceType: 'reactor' | 'proxy'
 ): string => {
-  const { state, requested } = resource;
+  const { state } = resource;
+  const requested = (resource as Record<string, unknown>).requested as
+    | Record<string, unknown>
+    | undefined;
   const resourceName = resourceType === 'reactor' ? 'Reactor' : 'Proxy';
   const parts = [`${resourceName} reached ${state} state`];
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,11 +1,5 @@
 import type { BasisTheory } from '@basis-theory/node-sdk';
 import { readFileContents } from '../files';
-import {
-  promptCommaSeparatedIfUndefined,
-  promptIntegerIfUndefined,
-  promptSelectIfUndefined,
-  promptStringIfUndefined,
-} from '../utils';
 
 const LEGACY_RUNTIME_IMAGE = 'node-bt';
 
@@ -210,79 +204,22 @@ const buildRuntime = (
   return runtime;
 };
 
-const promptRuntimeOptions = async (
-  flags: RuntimeFlags,
-  labelPrefix?: string
-): Promise<ConfigurableRuntimeOptions> => {
-  const prefix = labelPrefix ? `${labelPrefix}: ` : '';
-
-  const timeout = await promptIntegerIfUndefined(flags.timeout, {
-    message: `${prefix}Timeout in seconds (1-30, press Enter for default: 10):`,
-    min: 1,
-    max: 30,
+const promptRuntimeOptions = (
+  flags: RuntimeFlags
+): Promise<ConfigurableRuntimeOptions> =>
+  Promise.resolve({
+    timeout: flags.timeout,
+    warmConcurrency: flags['warm-concurrency'],
+    resources: flags.resources,
+    packageJson: flags['package-json'] || undefined,
+    permissions:
+      flags.permissions && flags.permissions.length > 0
+        ? flags.permissions
+        : undefined,
   });
 
-  const warmConcurrency = await promptIntegerIfUndefined(
-    flags['warm-concurrency'],
-    {
-      message: `${prefix}Warm concurrency (0-1, press Enter for default: 0):`,
-      min: 0,
-      max: 1,
-    }
-  );
-
-  const resources = await promptSelectIfUndefined(flags.resources, {
-    message: `${prefix}Resource tier:`,
-    choices: [
-      {
-        value: 'standard',
-        name: 'standard (default)',
-      },
-      {
-        value: 'large',
-        name: 'large',
-      },
-      {
-        value: 'xlarge',
-        name: 'xlarge',
-      },
-    ],
-  });
-
-  const packageJson = await promptStringIfUndefined(flags['package-json'], {
-    message: `${prefix}(Optional) Runtime package.json file path (JSON format):`,
-  });
-
-  const permissions = await promptCommaSeparatedIfUndefined(flags.permissions, {
-    message: `${prefix}(Optional) Permissions (comma-separated, e.g. token:read, token:create):`,
-  });
-
-  return {
-    timeout,
-    warmConcurrency,
-    resources,
-    packageJson: packageJson || undefined,
-    permissions,
-  };
-};
-
-const promptRuntimeImage = (
-  image: string | undefined,
-  message = 'Which runtime do you want to use?'
-): Promise<string> =>
-  promptSelectIfUndefined(image, {
-    message,
-    choices: [
-      {
-        value: LEGACY_RUNTIME_IMAGE,
-        name: `${LEGACY_RUNTIME_IMAGE} (legacy)`,
-      },
-      ...CONFIGURABLE_RUNTIME_IMAGES.map((runtime) => ({
-        value: runtime,
-        name: `${runtime} (configurable)`,
-      })),
-    ],
-  });
+const promptRuntimeImage = (image: string | undefined): Promise<string> =>
+  Promise.resolve(image ?? '');
 
 export {
   LEGACY_RUNTIME_IMAGE,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,183 +1,39 @@
-import checkbox from '@inquirer/checkbox';
-import confirm from '@inquirer/confirm';
-import input from '@inquirer/input';
-import select from '@inquirer/select';
-import { ux } from '@oclif/core';
-
 interface PaginatedList<T> {
   data: T[];
   page: number;
   hasNextPage: boolean;
 }
 
-const selectOrNavigate = async <T>(
-  list: PaginatedList<T>,
-  prop: string
-): Promise<'previous' | T | 'next'> => {
-  const { data, page, hasNextPage } = list;
+const resolveString = (value: string | undefined): Promise<string> =>
+  Promise.resolve(value ?? '');
 
-  let prompt = `Select one (${prop})`;
+const resolveSelect = (value: string | undefined): Promise<string> =>
+  Promise.resolve(value ?? '');
 
-  const hasNext = hasNextPage;
-  const hasPrevious = page > 1;
+const resolveCheckbox = (value: string[] | undefined): Promise<string[]> =>
+  Promise.resolve(value ?? []);
 
-  if (hasPrevious) {
-    prompt += " or 'p' for previous page ";
-  }
-
-  if (hasNext) {
-    prompt += " or 'n' for next page ";
-  }
-
-  const selection = await input({
-    message: prompt,
-  });
-
-  if (selection === 'p' && hasPrevious) {
-    return 'previous';
-  }
-
-  if (selection === 'n' && hasNext) {
-    return 'next';
-  }
-
-  const found = data.find(
-    (item) => selection === String((item as never)[prop])
-  );
-
-  if (found) {
-    return found;
-  }
-
-  ux.info('Invalid option.');
-
-  return selectOrNavigate(list, prop);
-};
-
-const promptStringIfUndefined = (
-  value: string | undefined,
-  options: Parameters<typeof input>[0]
-): Promise<string> => {
+const resolveUrl = (value: URL | undefined): Promise<URL> => {
   if (value) {
     return Promise.resolve(value);
   }
 
-  return input(options);
+  return Promise.reject(new Error('URL is required — provide via flag'));
 };
 
-const promptSelectIfUndefined = (
-  value: string | undefined,
-  options: Parameters<typeof select>[0]
-): Promise<string> => {
-  if (value) {
-    return Promise.resolve(value);
-  }
-
-  return select(options) as Promise<string>;
-};
-
-const promptCheckboxIfUndefined = (
-  value: string[] | undefined,
-  options: Parameters<typeof checkbox>[0]
-): Promise<string[]> => {
-  if (value) {
-    return Promise.resolve(value);
-  }
-
-  return checkbox(options) as Promise<string[]>;
-};
-
-const promptUrlIfUndefined = async (
-  value: URL | undefined,
-  options: Parameters<typeof input>[0]
-): Promise<URL> => {
-  if (value) {
-    return Promise.resolve(value);
-  }
-
-  return new URL(
-    await input({
-      validate: (val) => {
-        try {
-          // eslint-disable-next-line no-new
-          new URL(val);
-
-          return true;
-        } catch {
-          return 'Please enter a valid URL';
-        }
-      },
-      ...options,
-    })
-  );
-};
-
-const promptBooleanIfUndefined = (
+const resolveBoolean = (
   value: boolean | undefined,
-  options: Parameters<typeof confirm>[0]
-): Promise<boolean> => {
-  if (value !== undefined) {
-    return Promise.resolve(value);
-  }
+  defaultValue = false
+): Promise<boolean> => Promise.resolve(value ?? defaultValue);
 
-  return confirm(options);
-};
+const resolveInteger = (
+  value: number | undefined
+): Promise<number | undefined> => Promise.resolve(value);
 
-const promptIntegerIfUndefined = async (
-  value: number | undefined,
-  options: { message: string; min?: number; max?: number }
-): Promise<number | undefined> => {
-  if (value !== undefined) {
-    return value;
-  }
-
-  const result = await input({
-    message: options.message,
-    validate: (val) => {
-      if (!val.trim()) {
-        return true;
-      } // Allow empty for optional
-
-      const num = Number(val);
-
-      if (Number.isNaN(num) || !Number.isInteger(num)) {
-        return 'Please enter a valid integer';
-      }
-
-      if (options.min !== undefined && num < options.min) {
-        return `Value must be at least ${options.min}`;
-      }
-
-      if (options.max !== undefined && num > options.max) {
-        return `Value must be at most ${options.max}`;
-      }
-
-      return true;
-    },
-  });
-
-  return result.trim() ? Number(result) : undefined;
-};
-
-const promptCommaSeparatedIfUndefined = async (
-  value: string[] | undefined,
-  options: Parameters<typeof input>[0]
-): Promise<string[] | undefined> => {
-  if (value && value.length > 0) {
-    return value;
-  }
-
-  const result = await input(options);
-
-  if (!result.trim()) {
-    return undefined;
-  }
-
-  return result
-    .split(',')
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
-};
+const resolveCommaSeparated = (
+  value: string[] | undefined
+): Promise<string[] | undefined> =>
+  Promise.resolve(value && value.length > 0 ? value : undefined);
 
 const cleanUpOnExit = (action: () => unknown): typeof process =>
   process.on('SIGINT', async () => {
@@ -187,14 +43,13 @@ const cleanUpOnExit = (action: () => unknown): typeof process =>
   });
 
 export {
-  selectOrNavigate,
-  promptStringIfUndefined,
-  promptSelectIfUndefined,
-  promptCheckboxIfUndefined,
-  promptUrlIfUndefined,
-  promptBooleanIfUndefined,
-  promptIntegerIfUndefined,
-  promptCommaSeparatedIfUndefined,
+  resolveString as promptStringIfUndefined,
+  resolveSelect as promptSelectIfUndefined,
+  resolveCheckbox as promptCheckboxIfUndefined,
+  resolveUrl as promptUrlIfUndefined,
+  resolveBoolean as promptBooleanIfUndefined,
+  resolveInteger as promptIntegerIfUndefined,
+  resolveCommaSeparated as promptCommaSeparatedIfUndefined,
   cleanUpOnExit,
   PaginatedList,
 };

--- a/test/unit/commands/3ds/sessions/authenticate.test.ts
+++ b/test/unit/commands/3ds/sessions/authenticate.test.ts
@@ -50,10 +50,7 @@ describe('3ds sessions authenticate', () => {
   });
 
   it('requires data or file flag', async () => {
-    const result = await runCommand([
-      '3ds:sessions:authenticate',
-      'sess-1',
-    ]);
+    const result = await runCommand(['3ds:sessions:authenticate', 'sess-1']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain(

--- a/test/unit/commands/3ds/sessions/authenticate.test.ts
+++ b/test/unit/commands/3ds/sessions/authenticate.test.ts
@@ -1,0 +1,77 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { threedsFixtures } from '../../../fixtures/threeds';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('3ds sessions authenticate', () => {
+  let sessionsAuthenticateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sessionsAuthenticateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'threeds').get(() => ({
+      sessions: {
+        authenticate: sessionsAuthenticateStub,
+      },
+    }));
+
+    sessionsAuthenticateStub.resolves(threedsFixtures.authentication1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('authenticates a 3DS session', async () => {
+    const result = await runCommand([
+      '3ds:sessions:authenticate',
+      'sess-1',
+      '--data',
+      '{"authenticationCategory":"payment"}',
+    ]);
+
+    expect(result.stdout).to.contain('auth-1');
+    expect(sessionsAuthenticateStub.calledOnce).to.be.true;
+    const [sessionId, request] = sessionsAuthenticateStub.firstCall.args;
+
+    expect(sessionId).to.equal('sess-1');
+    expect(request.authenticationCategory).to.equal('payment');
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand([
+      '3ds:sessions:authenticate',
+      '--data',
+      '{"authenticationCategory":"payment"}',
+    ]);
+
+    expect(result.error).to.exist;
+  });
+
+  it('requires data or file flag', async () => {
+    const result = await runCommand([
+      '3ds:sessions:authenticate',
+      'sess-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided.'
+    );
+  });
+
+  it('handles API errors', async () => {
+    sessionsAuthenticateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      '3ds:sessions:authenticate',
+      'sess-1',
+      '--data',
+      '{"authenticationCategory":"payment"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/3ds/sessions/challenge-result.test.ts
+++ b/test/unit/commands/3ds/sessions/challenge-result.test.ts
@@ -1,0 +1,55 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { threedsFixtures } from '../../../fixtures/threeds';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('3ds sessions challenge-result', () => {
+  let sessionsGetChallengeResultStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sessionsGetChallengeResultStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'threeds').get(() => ({
+      sessions: {
+        getChallengeResult: sessionsGetChallengeResultStub,
+      },
+    }));
+
+    sessionsGetChallengeResultStub.resolves(threedsFixtures.challengeResult1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a challenge result by session id', async () => {
+    const result = await runCommand([
+      '3ds:sessions:challenge-result',
+      'sess-1',
+    ]);
+
+    expect(result.stdout).to.contain('auth-1');
+    expect(sessionsGetChallengeResultStub.calledOnce).to.be.true;
+    expect(sessionsGetChallengeResultStub.calledWith('sess-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['3ds:sessions:challenge-result']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    sessionsGetChallengeResultStub.rejects(new Error('Session not found'));
+
+    const result = await runCommand([
+      '3ds:sessions:challenge-result',
+      'sess-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Session not found');
+  });
+});

--- a/test/unit/commands/3ds/sessions/create.test.ts
+++ b/test/unit/commands/3ds/sessions/create.test.ts
@@ -1,0 +1,69 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { threedsFixtures } from '../../../fixtures/threeds';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('3ds sessions create', () => {
+  let sessionsCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sessionsCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'threeds').get(() => ({
+      sessions: {
+        create: sessionsCreateStub,
+      },
+    }));
+
+    sessionsCreateStub.resolves(threedsFixtures.session1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a 3DS session with flags', async () => {
+    const result = await runCommand([
+      '3ds:sessions:create',
+      '--token-id',
+      'tok-1',
+      '--type',
+      'browser',
+    ]);
+
+    expect(result.stdout).to.contain('sess-1');
+    expect(sessionsCreateStub.calledOnce).to.be.true;
+    const [request] = sessionsCreateStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+    expect(request.type).to.equal('browser');
+  });
+
+  it('creates a 3DS session with JSON data', async () => {
+    const result = await runCommand([
+      '3ds:sessions:create',
+      '--data',
+      '{"tokenId":"tok-1","type":"browser"}',
+    ]);
+
+    expect(result.stdout).to.contain('sess-1');
+    const [request] = sessionsCreateStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+    expect(request.type).to.equal('browser');
+  });
+
+  it('handles API errors', async () => {
+    sessionsCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      '3ds:sessions:create',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/3ds/sessions/get.test.ts
+++ b/test/unit/commands/3ds/sessions/get.test.ts
@@ -1,0 +1,49 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { threedsFixtures } from '../../../fixtures/threeds';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('3ds sessions get', () => {
+  let sessionsGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sessionsGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'threeds').get(() => ({
+      sessions: {
+        get: sessionsGetStub,
+      },
+    }));
+
+    sessionsGetStub.resolves(threedsFixtures.session1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a 3DS session by id', async () => {
+    const result = await runCommand(['3ds:sessions:get', 'sess-1']);
+
+    expect(result.stdout).to.contain('sess-1');
+    expect(sessionsGetStub.calledOnce).to.be.true;
+    expect(sessionsGetStub.calledWith('sess-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['3ds:sessions:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    sessionsGetStub.rejects(new Error('Session not found'));
+
+    const result = await runCommand(['3ds:sessions:get', 'sess-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Session not found');
+  });
+});

--- a/test/unit/commands/account-updater/jobs/create.test.ts
+++ b/test/unit/commands/account-updater/jobs/create.test.ts
@@ -1,0 +1,42 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { accountUpdaterFixtures } from '../../../fixtures/account-updater';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('account-updater jobs create', () => {
+  let jobsCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    jobsCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'accountUpdater').get(() => ({
+      jobs: {
+        create: jobsCreateStub,
+      },
+    }));
+
+    jobsCreateStub.resolves(accountUpdaterFixtures.job1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a job', async () => {
+    const result = await runCommand(['account-updater:jobs:create']);
+
+    expect(result.stdout).to.contain('Job created successfully!');
+    expect(result.stdout).to.contain('job-1');
+    expect(jobsCreateStub.calledOnce).to.be.true;
+  });
+
+  it('handles API errors', async () => {
+    jobsCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['account-updater:jobs:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/account-updater/jobs/get.test.ts
+++ b/test/unit/commands/account-updater/jobs/get.test.ts
@@ -1,0 +1,49 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { accountUpdaterFixtures } from '../../../fixtures/account-updater';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('account-updater jobs get', () => {
+  let jobsGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    jobsGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'accountUpdater').get(() => ({
+      jobs: {
+        get: jobsGetStub,
+      },
+    }));
+
+    jobsGetStub.resolves(accountUpdaterFixtures.job1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a job by id', async () => {
+    const result = await runCommand(['account-updater:jobs:get', 'job-1']);
+
+    expect(result.stdout).to.contain('job-1');
+    expect(jobsGetStub.calledOnce).to.be.true;
+    expect(jobsGetStub.calledWith('job-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['account-updater:jobs:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    jobsGetStub.rejects(new Error('Job not found'));
+
+    const result = await runCommand(['account-updater:jobs:get', 'job-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Job not found');
+  });
+});

--- a/test/unit/commands/account-updater/jobs/get.test.ts
+++ b/test/unit/commands/account-updater/jobs/get.test.ts
@@ -41,7 +41,10 @@ describe('account-updater jobs get', () => {
   it('handles API errors', async () => {
     jobsGetStub.rejects(new Error('Job not found'));
 
-    const result = await runCommand(['account-updater:jobs:get', 'job-invalid']);
+    const result = await runCommand([
+      'account-updater:jobs:get',
+      'job-invalid',
+    ]);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain('Job not found');

--- a/test/unit/commands/account-updater/jobs/index.test.ts
+++ b/test/unit/commands/account-updater/jobs/index.test.ts
@@ -1,0 +1,64 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { accountUpdaterFixtures } from '../../../fixtures/account-updater';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('account-updater jobs', () => {
+  let jobsListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    jobsListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'accountUpdater').get(() => ({
+      jobs: {
+        list: jobsListStub,
+      },
+    }));
+
+    jobsListStub.resolves({
+      data: [accountUpdaterFixtures.job1, accountUpdaterFixtures.job2],
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists jobs', async () => {
+    const result = await runCommand(['account-updater:jobs']);
+
+    expect(result.stdout).to.contain('job-1');
+    expect(result.stdout).to.contain('pending');
+    expect(jobsListStub.calledOnce).to.be.true;
+  });
+
+  it('passes size flag', async () => {
+    const result = await runCommand([
+      'account-updater:jobs',
+      '--size',
+      '10',
+    ]);
+
+    expect(result.stdout).to.contain('job-1');
+    expect(jobsListStub.calledOnce).to.be.true;
+    expect(jobsListStub.firstCall.args[0]).to.deep.include({ size: 10 });
+  });
+
+  it('handles empty results', async () => {
+    jobsListStub.resolves({ data: [] });
+
+    const result = await runCommand(['account-updater:jobs']);
+
+    expect(result.stdout).to.contain('No jobs found.');
+  });
+
+  it('handles API errors', async () => {
+    jobsListStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['account-updater:jobs']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/account-updater/jobs/index.test.ts
+++ b/test/unit/commands/account-updater/jobs/index.test.ts
@@ -34,11 +34,7 @@ describe('account-updater jobs', () => {
   });
 
   it('passes size flag', async () => {
-    const result = await runCommand([
-      'account-updater:jobs',
-      '--size',
-      '10',
-    ]);
+    const result = await runCommand(['account-updater:jobs', '--size', '10']);
 
     expect(result.stdout).to.contain('job-1');
     expect(jobsListStub.calledOnce).to.be.true;

--- a/test/unit/commands/account-updater/real-time.test.ts
+++ b/test/unit/commands/account-updater/real-time.test.ts
@@ -1,0 +1,80 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { accountUpdaterFixtures } from '../../fixtures/account-updater';
+import { runCommand } from '../../helpers/run-command';
+
+describe('account-updater real-time', () => {
+  let realTimeInvokeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    realTimeInvokeStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'accountUpdater').get(() => ({
+      realTime: {
+        invoke: realTimeInvokeStub,
+      },
+    }));
+
+    realTimeInvokeStub.resolves(accountUpdaterFixtures.realTimeResponse);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('invokes real-time account updater', async () => {
+    const result = await runCommand([
+      'account-updater:real-time',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(realTimeInvokeStub.calledOnce).to.be.true;
+    const [request] = realTimeInvokeStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+  });
+
+  it('passes optional flags', async () => {
+    const result = await runCommand([
+      'account-updater:real-time',
+      '--token-id',
+      'tok-1',
+      '--expiration-month',
+      '12',
+      '--expiration-year',
+      '2025',
+      '--deduplicate-token',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    const [request] = realTimeInvokeStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+    expect(request.expirationMonth).to.equal(12);
+    expect(request.expirationYear).to.equal(2025);
+    expect(request.deduplicateToken).to.equal(true);
+  });
+
+  it('requires token-id flag', async () => {
+    const result = await runCommand(['account-updater:real-time']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    realTimeInvokeStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'account-updater:real-time',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/apple-pay/create.test.ts
+++ b/test/unit/commands/apple-pay/create.test.ts
@@ -1,0 +1,82 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayCreateResponseFixture } from '../../fixtures/apple-pay';
+import { runCommand } from '../../helpers/run-command';
+
+describe('apple-pay create', () => {
+  let applePayCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    applePayCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      create: applePayCreateStub,
+    }));
+
+    applePayCreateStub.resolves(applePayCreateResponseFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates an apple pay token with --data', async () => {
+    const paymentData = JSON.stringify({ token: 'abc' });
+
+    const result = await runCommand([
+      'apple-pay:create',
+      '--data',
+      paymentData,
+    ]);
+
+    expect(result.stdout).to.contain('ap-1');
+    expect(applePayCreateStub.calledOnce).to.be.true;
+    expect(applePayCreateStub.firstCall.args[0].applePaymentData).to.deep.equal(
+      { token: 'abc' }
+    );
+  });
+
+  it('passes expires-at and merchant-registration-id', async () => {
+    const paymentData = JSON.stringify({ token: 'abc' });
+
+    await runCommand([
+      'apple-pay:create',
+      '--data',
+      paymentData,
+      '--expires-at',
+      '2025-12-31',
+      '--merchant-registration-id',
+      'mr-1',
+    ]);
+
+    expect(applePayCreateStub.firstCall.args[0].expiresAt).to.equal(
+      '2025-12-31'
+    );
+    expect(
+      applePayCreateStub.firstCall.args[0].merchantRegistrationId
+    ).to.equal('mr-1');
+  });
+
+  it('requires --data or --file', async () => {
+    const result = await runCommand(['apple-pay:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided'
+    );
+  });
+
+  it('handles API errors', async () => {
+    applePayCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'apple-pay:create',
+      '--data',
+      '{"token":"abc"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/apple-pay/delete.test.ts
+++ b/test/unit/commands/apple-pay/delete.test.ts
@@ -26,15 +26,9 @@ describe('apple-pay delete', () => {
 
   describe('with --force flag', () => {
     it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'apple-pay:delete',
-        'ap-1',
-        '--force',
-      ]);
+      const result = await runCommand(['apple-pay:delete', 'ap-1', '--force']);
 
-      expect(result.stdout).to.contain(
-        'Apple Pay token deleted successfully!'
-      );
+      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
       expect(applePayDeleteStub.calledOnce).to.be.true;
       expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
       expect(confirmStub.called).to.be.false;
@@ -43,9 +37,7 @@ describe('apple-pay delete', () => {
     it('accepts -f shorthand flag', async () => {
       const result = await runCommand(['apple-pay:delete', 'ap-1', '-f']);
 
-      expect(result.stdout).to.contain(
-        'Apple Pay token deleted successfully!'
-      );
+      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
       expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
     });
   });
@@ -56,9 +48,7 @@ describe('apple-pay delete', () => {
 
       const result = await runCommand(['apple-pay:delete', 'ap-1']);
 
-      expect(result.stdout).to.contain(
-        'Apple Pay token deleted successfully!'
-      );
+      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
       expect(confirmStub.calledOnce).to.be.true;
       expect(applePayDeleteStub.calledOnce).to.be.true;
     });
@@ -89,11 +79,7 @@ describe('apple-pay delete', () => {
     it('handles API errors', async () => {
       applePayDeleteStub.rejects(new Error('Not found'));
 
-      const result = await runCommand([
-        'apple-pay:delete',
-        'ap-1',
-        '--force',
-      ]);
+      const result = await runCommand(['apple-pay:delete', 'ap-1', '--force']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Not found');

--- a/test/unit/commands/apple-pay/delete.test.ts
+++ b/test/unit/commands/apple-pay/delete.test.ts
@@ -1,0 +1,102 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('apple-pay delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let applePayDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    applePayDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      delete: applePayDeleteStub,
+    }));
+
+    applePayDeleteStub.resolves('deleted');
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'apple-pay:delete',
+        'ap-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay token deleted successfully!'
+      );
+      expect(applePayDeleteStub.calledOnce).to.be.true;
+      expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['apple-pay:delete', 'ap-1', '-f']);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay token deleted successfully!'
+      );
+      expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['apple-pay:delete', 'ap-1']);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay token deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(applePayDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['apple-pay:delete', 'ap-1']);
+
+      expect(result.stdout).to.not.contain(
+        'Apple Pay token deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(applePayDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires id argument', async () => {
+      const result = await runCommand(['apple-pay:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      applePayDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'apple-pay:delete',
+        'ap-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/apple-pay/delete.test.ts
+++ b/test/unit/commands/apple-pay/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('apple-pay delete', () => {
-  let confirmStub: sinon.SinonStub;
   let applePayDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     applePayDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
@@ -17,53 +14,33 @@ describe('apple-pay delete', () => {
     }));
 
     applePayDeleteStub.resolves('deleted');
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand(['apple-pay:delete', 'ap-1', '--force']);
+  it('deletes apple pay token', async () => {
+    const result = await runCommand(['apple-pay:delete', 'ap-1']);
 
-      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
-      expect(applePayDeleteStub.calledOnce).to.be.true;
-      expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['apple-pay:delete', 'ap-1', '-f']);
-
-      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
-      expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
+    expect(applePayDeleteStub.calledOnce).to.be.true;
+    expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['apple-pay:delete', 'ap-1', '--force']);
 
-      const result = await runCommand(['apple-pay:delete', 'ap-1']);
+    expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
+    expect(applePayDeleteStub.calledOnce).to.be.true;
+    expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(applePayDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['apple-pay:delete', 'ap-1', '-f']);
 
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['apple-pay:delete', 'ap-1']);
-
-      expect(result.stdout).to.not.contain(
-        'Apple Pay token deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(applePayDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Apple Pay token deleted successfully!');
+    expect(applePayDeleteStub.calledWith('ap-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/apple-pay/domains/deregister.test.ts
+++ b/test/unit/commands/apple-pay/domains/deregister.test.ts
@@ -1,0 +1,58 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay domains deregister', () => {
+  let domainDeregisterStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    domainDeregisterStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      domain: {
+        deregister: domainDeregisterStub,
+      },
+    }));
+
+    domainDeregisterStub.resolves(undefined);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('deregisters a domain', async () => {
+    const result = await runCommand([
+      'apple-pay:domains:deregister',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.stdout).to.contain('Domain deregistered successfully!');
+    expect(domainDeregisterStub.calledOnce).to.be.true;
+    expect(domainDeregisterStub.firstCall.args[0].domain).to.equal(
+      'example.com'
+    );
+  });
+
+  it('requires --domain flag', async () => {
+    const result = await runCommand(['apple-pay:domains:deregister']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    domainDeregisterStub.rejects(new Error('Deregistration failed'));
+
+    const result = await runCommand([
+      'apple-pay:domains:deregister',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Deregistration failed');
+  });
+});

--- a/test/unit/commands/apple-pay/domains/index.test.ts
+++ b/test/unit/commands/apple-pay/domains/index.test.ts
@@ -1,0 +1,42 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayDomainFixture } from '../../../fixtures/apple-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay domains', () => {
+  let domainGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    domainGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      domain: {
+        get: domainGetStub,
+      },
+    }));
+
+    domainGetStub.resolves(applePayDomainFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists registered domains', async () => {
+    const result = await runCommand(['apple-pay:domains']);
+
+    expect(result.stdout).to.contain('example.com');
+    expect(result.stdout).to.contain('shop.example.com');
+    expect(domainGetStub.calledOnce).to.be.true;
+  });
+
+  it('handles API errors', async () => {
+    domainGetStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['apple-pay:domains']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/apple-pay/domains/register.test.ts
+++ b/test/unit/commands/apple-pay/domains/register.test.ts
@@ -32,9 +32,7 @@ describe('apple-pay domains register', () => {
 
     expect(result.stdout).to.contain('example.com');
     expect(domainRegisterStub.calledOnce).to.be.true;
-    expect(domainRegisterStub.firstCall.args[0].domain).to.equal(
-      'example.com'
-    );
+    expect(domainRegisterStub.firstCall.args[0].domain).to.equal('example.com');
   });
 
   it('requires --domain flag', async () => {

--- a/test/unit/commands/apple-pay/domains/register.test.ts
+++ b/test/unit/commands/apple-pay/domains/register.test.ts
@@ -1,0 +1,59 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayDomainRegisterFixture } from '../../../fixtures/apple-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay domains register', () => {
+  let domainRegisterStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    domainRegisterStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      domain: {
+        register: domainRegisterStub,
+      },
+    }));
+
+    domainRegisterStub.resolves(applePayDomainRegisterFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers a domain', async () => {
+    const result = await runCommand([
+      'apple-pay:domains:register',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.stdout).to.contain('example.com');
+    expect(domainRegisterStub.calledOnce).to.be.true;
+    expect(domainRegisterStub.firstCall.args[0].domain).to.equal(
+      'example.com'
+    );
+  });
+
+  it('requires --domain flag', async () => {
+    const result = await runCommand(['apple-pay:domains:register']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    domainRegisterStub.rejects(new Error('Registration failed'));
+
+    const result = await runCommand([
+      'apple-pay:domains:register',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Registration failed');
+  });
+});

--- a/test/unit/commands/apple-pay/get.test.ts
+++ b/test/unit/commands/apple-pay/get.test.ts
@@ -1,0 +1,47 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayTokenFixture } from '../../fixtures/apple-pay';
+import { runCommand } from '../../helpers/run-command';
+
+describe('apple-pay get', () => {
+  let applePayGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    applePayGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      get: applePayGetStub,
+    }));
+
+    applePayGetStub.resolves(applePayTokenFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets an apple pay token by id', async () => {
+    const result = await runCommand(['apple-pay:get', 'ap-1']);
+
+    expect(result.stdout).to.contain('ap-1');
+    expect(applePayGetStub.calledOnce).to.be.true;
+    expect(applePayGetStub.calledWith('ap-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['apple-pay:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    applePayGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand(['apple-pay:get', 'ap-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/certificates/create.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/create.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
+import fs from 'fs';
 import sinon from 'sinon';
 import { applePayMerchantCertificatesFixture } from '../../../../fixtures/apple-pay';
 import { runCommand } from '../../../../helpers/run-command';
@@ -56,8 +56,7 @@ describe('apple-pay merchants certificates create', () => {
       certificatesCreateStub.firstCall.args[1].merchantCertificatePassword
     ).to.equal('pass1');
     expect(
-      certificatesCreateStub.firstCall.args[1]
-        .paymentProcessorCertificateData
+      certificatesCreateStub.firstCall.args[1].paymentProcessorCertificateData
     ).to.equal(Buffer.from('cert-data').toString('base64'));
     expect(
       certificatesCreateStub.firstCall.args[1]

--- a/test/unit/commands/apple-pay/merchants/certificates/create.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/create.test.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayMerchantCertificatesFixture } from '../../../../fixtures/apple-pay';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('apple-pay merchants certificates create', () => {
+  let certificatesCreateStub: sinon.SinonStub;
+  let readFileSyncStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    certificatesCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        certificates: {
+          create: certificatesCreateStub,
+        },
+      },
+    }));
+
+    certificatesCreateStub.resolves(applePayMerchantCertificatesFixture);
+
+    readFileSyncStub = sinon.stub(fs, 'readFileSync');
+    readFileSyncStub.returns(Buffer.from('cert-data'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates certificates', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert',
+      '/path/to/merchant.p12',
+      '--merchant-cert-password',
+      'pass1',
+      '--processor-cert',
+      '/path/to/processor.pem',
+      '--processor-cert-password',
+      'pass2',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.stdout).to.contain('cert-1');
+    expect(certificatesCreateStub.calledOnce).to.be.true;
+    expect(certificatesCreateStub.firstCall.args[0]).to.equal('merch-1');
+    expect(
+      certificatesCreateStub.firstCall.args[1].merchantCertificateData
+    ).to.equal(Buffer.from('cert-data').toString('base64'));
+    expect(
+      certificatesCreateStub.firstCall.args[1].merchantCertificatePassword
+    ).to.equal('pass1');
+    expect(
+      certificatesCreateStub.firstCall.args[1]
+        .paymentProcessorCertificateData
+    ).to.equal(Buffer.from('cert-data').toString('base64'));
+    expect(
+      certificatesCreateStub.firstCall.args[1]
+        .paymentProcessorCertificatePassword
+    ).to.equal('pass2');
+    expect(certificatesCreateStub.firstCall.args[1].domain).to.equal(
+      'example.com'
+    );
+  });
+
+  it('requires merchant-id argument', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:create',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('requires --merchant-cert flag', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert-password',
+      'pass1',
+      '--processor-cert',
+      '/path/to/processor.pem',
+      '--processor-cert-password',
+      'pass2',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    certificatesCreateStub.rejects(new Error('Certificate error'));
+
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert',
+      '/path/to/merchant.p12',
+      '--merchant-cert-password',
+      'pass1',
+      '--processor-cert',
+      '/path/to/processor.pem',
+      '--processor-cert-password',
+      'pass2',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Certificate error');
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../../helpers/run-command';
 
 describe('apple-pay merchants certificates delete', () => {
-  let confirmStub: sinon.SinonStub;
   let certificatesDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     certificatesDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
@@ -21,63 +18,39 @@ describe('apple-pay merchants certificates delete', () => {
     }));
 
     certificatesDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'apple-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-        '--force',
-      ]);
+  it('deletes apple pay merchant certificate', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:delete',
+      'merch-1',
+      'cert-1',
+    ]);
 
-      expect(result.stdout).to.contain(
-        'Apple Pay merchant certificate deleted successfully!'
-      );
-      expect(certificatesDeleteStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Apple Pay merchant certificate deleted successfully!'
+    );
+    expect(certificatesDeleteStub.calledOnce).to.be.true;
+    expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:delete',
+      'merch-1',
+      'cert-1',
+      '--force',
+    ]);
 
-      const result = await runCommand([
-        'apple-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-      ]);
-
-      expect(result.stdout).to.contain(
-        'Apple Pay merchant certificate deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledOnce).to.be.true;
-    });
-
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand([
-        'apple-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-      ]);
-
-      expect(result.stdout).to.not.contain(
-        'Apple Pay merchant certificate deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Apple Pay merchant certificate deleted successfully!'
+    );
+    expect(certificatesDeleteStub.calledOnce).to.be.true;
+    expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
@@ -41,8 +41,7 @@ describe('apple-pay merchants certificates delete', () => {
         'Apple Pay merchant certificate deleted successfully!'
       );
       expect(certificatesDeleteStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be
-        .true;
+      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
       expect(confirmStub.called).to.be.false;
     });
   });

--- a/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/delete.test.ts
@@ -1,0 +1,110 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('apple-pay merchants certificates delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let certificatesDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    certificatesDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        certificates: {
+          delete: certificatesDeleteStub,
+        },
+      },
+    }));
+
+    certificatesDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'apple-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay merchant certificate deleted successfully!'
+      );
+      expect(certificatesDeleteStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be
+        .true;
+      expect(confirmStub.called).to.be.false;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'apple-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay merchant certificate deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'apple-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+      ]);
+
+      expect(result.stdout).to.not.contain(
+        'Apple Pay merchant certificate deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires merchant-id and certificate-id arguments', async () => {
+      const result = await runCommand([
+        'apple-pay:merchants:certificates:delete',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 2 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      certificatesDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'apple-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/certificates/get.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/get.test.ts
@@ -1,0 +1,71 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayMerchantCertificatesFixture } from '../../../../fixtures/apple-pay';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('apple-pay merchants certificates get', () => {
+  let certificatesGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    certificatesGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        certificates: {
+          get: certificatesGetStub,
+        },
+      },
+    }));
+
+    certificatesGetStub.resolves(applePayMerchantCertificatesFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets certificates by merchant and certificate id', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:get',
+      'merch-1',
+      'cert-1',
+    ]);
+
+    expect(result.stdout).to.contain('cert-1');
+    expect(certificatesGetStub.calledOnce).to.be.true;
+    expect(certificatesGetStub.calledWith('merch-1', 'cert-1')).to.be.true;
+  });
+
+  it('requires merchant-id and certificate-id arguments', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:get',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 2 required arg');
+  });
+
+  it('requires certificate-id argument', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:get',
+      'merch-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    certificatesGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand([
+      'apple-pay:merchants:certificates:get',
+      'merch-1',
+      'cert-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/certificates/get.test.ts
+++ b/test/unit/commands/apple-pay/merchants/certificates/get.test.ts
@@ -38,9 +38,7 @@ describe('apple-pay merchants certificates get', () => {
   });
 
   it('requires merchant-id and certificate-id arguments', async () => {
-    const result = await runCommand([
-      'apple-pay:merchants:certificates:get',
-    ]);
+    const result = await runCommand(['apple-pay:merchants:certificates:get']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain('Missing 2 required arg');

--- a/test/unit/commands/apple-pay/merchants/create.test.ts
+++ b/test/unit/commands/apple-pay/merchants/create.test.ts
@@ -33,9 +33,9 @@ describe('apple-pay merchants create', () => {
     expect(result.stdout).to.contain('merch-1');
     expect(result.stdout).to.contain('merchant.com.example');
     expect(merchantCreateStub.calledOnce).to.be.true;
-    expect(
-      merchantCreateStub.firstCall.args[0].merchantIdentifier
-    ).to.equal('merchant.com.example');
+    expect(merchantCreateStub.firstCall.args[0].merchantIdentifier).to.equal(
+      'merchant.com.example'
+    );
   });
 
   it('requires --merchant-identifier flag', async () => {

--- a/test/unit/commands/apple-pay/merchants/create.test.ts
+++ b/test/unit/commands/apple-pay/merchants/create.test.ts
@@ -1,0 +1,60 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayMerchantFixture } from '../../../fixtures/apple-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay merchants create', () => {
+  let merchantCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    merchantCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        create: merchantCreateStub,
+      },
+    }));
+
+    merchantCreateStub.resolves(applePayMerchantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a merchant', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:create',
+      '--merchant-identifier',
+      'merchant.com.example',
+    ]);
+
+    expect(result.stdout).to.contain('merch-1');
+    expect(result.stdout).to.contain('merchant.com.example');
+    expect(merchantCreateStub.calledOnce).to.be.true;
+    expect(
+      merchantCreateStub.firstCall.args[0].merchantIdentifier
+    ).to.equal('merchant.com.example');
+  });
+
+  it('requires --merchant-identifier flag', async () => {
+    const result = await runCommand(['apple-pay:merchants:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    merchantCreateStub.rejects(new Error('Creation failed'));
+
+    const result = await runCommand([
+      'apple-pay:merchants:create',
+      '--merchant-identifier',
+      'merchant.com.example',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Creation failed');
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/delete.test.ts
@@ -1,0 +1,101 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay merchants delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let merchantDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    merchantDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        delete: merchantDeleteStub,
+      },
+    }));
+
+    merchantDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'apple-pay:merchants:delete',
+        'merch-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay merchant deleted successfully!'
+      );
+      expect(merchantDeleteStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'apple-pay:merchants:delete',
+        'merch-1',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Apple Pay merchant deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'apple-pay:merchants:delete',
+        'merch-1',
+      ]);
+
+      expect(result.stdout).to.not.contain(
+        'Apple Pay merchant deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires id argument', async () => {
+      const result = await runCommand(['apple-pay:merchants:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      merchantDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'apple-pay:merchants:delete',
+        'merch-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/apple-pay/merchants/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('apple-pay merchants delete', () => {
-  let confirmStub: sinon.SinonStub;
   let merchantDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     merchantDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
@@ -19,60 +16,37 @@ describe('apple-pay merchants delete', () => {
     }));
 
     merchantDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'apple-pay:merchants:delete',
-        'merch-1',
-        '--force',
-      ]);
+  it('deletes apple pay merchant', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:delete',
+      'merch-1',
+    ]);
 
-      expect(result.stdout).to.contain(
-        'Apple Pay merchant deleted successfully!'
-      );
-      expect(merchantDeleteStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Apple Pay merchant deleted successfully!'
+    );
+    expect(merchantDeleteStub.calledOnce).to.be.true;
+    expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'apple-pay:merchants:delete',
+      'merch-1',
+      '--force',
+    ]);
 
-      const result = await runCommand([
-        'apple-pay:merchants:delete',
-        'merch-1',
-      ]);
-
-      expect(result.stdout).to.contain(
-        'Apple Pay merchant deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.calledOnce).to.be.true;
-    });
-
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand([
-        'apple-pay:merchants:delete',
-        'merch-1',
-      ]);
-
-      expect(result.stdout).to.not.contain(
-        'Apple Pay merchant deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Apple Pay merchant deleted successfully!'
+    );
+    expect(merchantDeleteStub.calledOnce).to.be.true;
+    expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/apple-pay/merchants/delete.test.ts
+++ b/test/unit/commands/apple-pay/merchants/delete.test.ts
@@ -23,10 +23,7 @@ describe('apple-pay merchants delete', () => {
   });
 
   it('deletes apple pay merchant', async () => {
-    const result = await runCommand([
-      'apple-pay:merchants:delete',
-      'merch-1',
-    ]);
+    const result = await runCommand(['apple-pay:merchants:delete', 'merch-1']);
 
     expect(result.stdout).to.contain(
       'Apple Pay merchant deleted successfully!'

--- a/test/unit/commands/apple-pay/merchants/get.test.ts
+++ b/test/unit/commands/apple-pay/merchants/get.test.ts
@@ -1,0 +1,53 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePayMerchantFixture } from '../../../fixtures/apple-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('apple-pay merchants get', () => {
+  let merchantGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    merchantGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      merchant: {
+        get: merchantGetStub,
+      },
+    }));
+
+    merchantGetStub.resolves(applePayMerchantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a merchant by id', async () => {
+    const result = await runCommand(['apple-pay:merchants:get', 'merch-1']);
+
+    expect(result.stdout).to.contain('merch-1');
+    expect(result.stdout).to.contain('merchant.com.example');
+    expect(merchantGetStub.calledOnce).to.be.true;
+    expect(merchantGetStub.calledWith('merch-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['apple-pay:merchants:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    merchantGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand([
+      'apple-pay:merchants:get',
+      'merch-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/apple-pay/session.test.ts
+++ b/test/unit/commands/apple-pay/session.test.ts
@@ -1,0 +1,100 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { applePaySessionFixture } from '../../fixtures/apple-pay';
+import { runCommand } from '../../helpers/run-command';
+
+describe('apple-pay session', () => {
+  let sessionCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sessionCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'applePay').get(() => ({
+      session: {
+        create: sessionCreateStub,
+      },
+    }));
+
+    sessionCreateStub.resolves(applePaySessionFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a session', async () => {
+    const result = await runCommand([
+      'apple-pay:session',
+      '--display-name',
+      'Test Store',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.stdout).to.contain('session-123');
+    expect(sessionCreateStub.calledOnce).to.be.true;
+    expect(sessionCreateStub.firstCall.args[0].displayName).to.equal(
+      'Test Store'
+    );
+    expect(sessionCreateStub.firstCall.args[0].domain).to.equal('example.com');
+  });
+
+  it('passes optional flags', async () => {
+    await runCommand([
+      'apple-pay:session',
+      '--display-name',
+      'Test Store',
+      '--domain',
+      'example.com',
+      '--validation-url',
+      'https://validate.example.com',
+      '--merchant-registration-id',
+      'mr-1',
+    ]);
+
+    expect(sessionCreateStub.firstCall.args[0].validationUrl).to.equal(
+      'https://validate.example.com'
+    );
+    expect(
+      sessionCreateStub.firstCall.args[0].merchantRegistrationId
+    ).to.equal('mr-1');
+  });
+
+  it('requires --display-name flag', async () => {
+    const result = await runCommand([
+      'apple-pay:session',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('requires --domain flag', async () => {
+    const result = await runCommand([
+      'apple-pay:session',
+      '--display-name',
+      'Test Store',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    sessionCreateStub.rejects(new Error('Session error'));
+
+    const result = await runCommand([
+      'apple-pay:session',
+      '--display-name',
+      'Test Store',
+      '--domain',
+      'example.com',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Session error');
+  });
+});

--- a/test/unit/commands/apple-pay/session.test.ts
+++ b/test/unit/commands/apple-pay/session.test.ts
@@ -56,9 +56,9 @@ describe('apple-pay session', () => {
     expect(sessionCreateStub.firstCall.args[0].validationUrl).to.equal(
       'https://validate.example.com'
     );
-    expect(
-      sessionCreateStub.firstCall.args[0].merchantRegistrationId
-    ).to.equal('mr-1');
+    expect(sessionCreateStub.firstCall.args[0].merchantRegistrationId).to.equal(
+      'mr-1'
+    );
   });
 
   it('requires --display-name flag', async () => {

--- a/test/unit/commands/applications/create.test.ts
+++ b/test/unit/commands/applications/create.test.ts
@@ -1,8 +1,4 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as checkbox from '@inquirer/checkbox';
-import * as confirm from '@inquirer/confirm';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
@@ -11,13 +7,8 @@ import {
   applicationTemplateFixtures,
 } from '../../fixtures/applications';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('applications create', () => {
-  let inputStub: PromptStub;
-  let selectStub: PromptStub;
-  let checkboxStub: PromptStub;
-  let confirmStub: PromptStub;
   let applicationsCreateStub: sinon.SinonStub;
   let applicationsGetStub: sinon.SinonStub;
   let permissionsListStub: sinon.SinonStub;
@@ -25,10 +16,6 @@ describe('applications create', () => {
   let applicationTemplatesGetStub: sinon.SinonStub;
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
-    checkboxStub = new PromptStub(sinon.stub(checkbox, 'default'));
-    confirmStub = new PromptStub(sinon.stub(confirm, 'default'));
     applicationsCreateStub = sinon.stub();
     applicationsGetStub = sinon.stub();
     permissionsListStub = sinon.stub();
@@ -131,48 +118,6 @@ describe('applications create', () => {
       expect(result.stdout).to.contain('Application created successfully!');
       expect(applicationTemplatesGetStub.calledWith('template-1')).to.be.true;
       expect(applicationsCreateStub.calledOnce).to.be.true;
-    });
-  });
-
-  describe('with prompts', () => {
-    it('prompts for all fields when no flags provided', async () => {
-      confirmStub.resolves(false); // Don't use template
-      inputStub.onCallResolves('What is the Application name?', 'Prompted App');
-      selectStub.onCallResolves('What is the Application type?', 'private');
-      checkboxStub.onCallResolves(
-        'Select the permissions for the Application',
-        ['token:read']
-      );
-
-      const result = await runCommand(['applications:create']);
-
-      expect(result.stdout).to.contain('Application created successfully!');
-      confirmStub.expectCalledWith(
-        'Do you want to use an application template?'
-      );
-      inputStub.verifyExpectations();
-      selectStub.verifyExpectations();
-      checkboxStub.verifyExpectations();
-    });
-
-    it('prompts for template when no flags provided', async () => {
-      confirmStub.resolves(true); // Use template
-      selectStub
-        .onCallResolves('Which template type do you want to use?', 'official')
-        .onCallResolves('Choose a template', applicationTemplateFixtures[0]);
-      inputStub.onCallResolves(
-        'What is the Application name?',
-        'App from Template'
-      );
-
-      const result = await runCommand(['applications:create']);
-
-      expect(result.stdout).to.contain('Application created successfully!');
-      confirmStub.expectCalledWith(
-        'Do you want to use an application template?'
-      );
-      selectStub.verifyExpectations();
-      inputStub.verifyExpectations();
     });
   });
 

--- a/test/unit/commands/applications/delete.test.ts
+++ b/test/unit/commands/applications/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('applications delete', () => {
-  let confirmStub: sinon.SinonStub;
   let applicationsDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     applicationsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'applications').get(() => ({
@@ -17,55 +14,37 @@ describe('applications delete', () => {
     }));
 
     applicationsDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --yes flag', () => {
-    it('deletes application without confirmation prompt', async () => {
-      const result = await runCommand([
-        'applications:delete',
-        'app-123',
-        '--yes',
-      ]);
+  it('deletes application', async () => {
+    const result = await runCommand(['applications:delete', 'app-123']);
 
-      expect(result.stdout).to.contain('Application deleted successfully!');
-      expect(applicationsDeleteStub.calledOnce).to.be.true;
-      expect(applicationsDeleteStub.calledWith('app-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -y shorthand flag', async () => {
-      const result = await runCommand(['applications:delete', 'app-456', '-y']);
-
-      expect(result.stdout).to.contain('Application deleted successfully!');
-      expect(applicationsDeleteStub.calledWith('app-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Application deleted successfully!');
+    expect(applicationsDeleteStub.calledOnce).to.be.true;
+    expect(applicationsDeleteStub.calledWith('app-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes application when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --yes flag', async () => {
+    const result = await runCommand([
+      'applications:delete',
+      'app-123',
+      '--yes',
+    ]);
 
-      const result = await runCommand(['applications:delete', 'app-123']);
+    expect(result.stdout).to.contain('Application deleted successfully!');
+    expect(applicationsDeleteStub.calledOnce).to.be.true;
+    expect(applicationsDeleteStub.calledWith('app-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Application deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(applicationsDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -y shorthand flag', async () => {
+    const result = await runCommand(['applications:delete', 'app-456', '-y']);
 
-    it('does not delete application when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['applications:delete', 'app-123']);
-
-      expect(result.stdout).to.not.contain('Application deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(applicationsDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Application deleted successfully!');
+    expect(applicationsDeleteStub.calledWith('app-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/applications/index.test.ts
+++ b/test/unit/commands/applications/index.test.ts
@@ -50,11 +50,8 @@ describe('applications list', () => {
 
     await runCommand(['applications', '--page', '2']);
 
-    expect(
-      applicationsListStub.calledWith(
-        sinon.match({ page: 2 })
-      )
-    ).to.be.true;
+    expect(applicationsListStub.calledWith(sinon.match({ page: 2 }))).to.be
+      .true;
   });
 
   it('supports --size flag', async () => {
@@ -62,10 +59,7 @@ describe('applications list', () => {
 
     await runCommand(['applications', '--size', '10']);
 
-    expect(
-      applicationsListStub.calledWith(
-        sinon.match({ size: 10 })
-      )
-    ).to.be.true;
+    expect(applicationsListStub.calledWith(sinon.match({ size: 10 }))).to.be
+      .true;
   });
 });

--- a/test/unit/commands/applications/index.test.ts
+++ b/test/unit/commands/applications/index.test.ts
@@ -1,31 +1,18 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { applicationFixtures } from '../../fixtures/applications';
 import { createPaginatedResponse } from '../../helpers/pagination';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('applications list', () => {
-  let inputStub: PromptStub;
-  let selectStub: PromptStub;
-  let confirmStub: PromptStub;
   let applicationsListStub: sinon.SinonStub;
-  let applicationsDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
-    confirmStub = new PromptStub(sinon.stub(confirm, 'default'));
     applicationsListStub = sinon.stub();
-    applicationsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'applications').get(() => ({
       list: applicationsListStub,
-      delete: applicationsDeleteStub,
     }));
   });
 
@@ -33,85 +20,52 @@ describe('applications list', () => {
     sinon.restore();
   });
 
-  describe('listing applications', () => {
-    it('displays applications and shows details when selected', async () => {
-      applicationsListStub.resolves(
-        createPaginatedResponse([
-          applicationFixtures.private,
-          applicationFixtures.management,
-        ])
-      );
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+  it('displays applications in a table', async () => {
+    applicationsListStub.resolves(
+      createPaginatedResponse([
+        applicationFixtures.private,
+        applicationFixtures.management,
+      ])
+    );
 
-      const result = await runCommand(['applications']);
+    const result = await runCommand(['applications']);
 
-      expect(result.stdout).to.contain('app-1');
-      expect(result.stdout).to.contain('Test Private App');
-      expect(applicationsListStub.calledOnce).to.be.true;
-      inputStub.verifyExpectations();
-      selectStub.verifyExpectations();
-    });
-
-    it('displays message when no applications found', async () => {
-      applicationsListStub.resolves(createPaginatedResponse([]));
-
-      const result = await runCommand(['applications']);
-
-      expect(result.stdout).to.contain('No applications found');
-    });
-
-    it('supports pagination with --page flag', async () => {
-      applicationsListStub.resolves(createPaginatedResponse([]));
-
-      await runCommand(['applications', '--page', '2']);
-
-      expect(
-        applicationsListStub.calledWith({
-          size: 5,
-          page: 2,
-        })
-      ).to.be.true;
-    });
+    expect(result.stdout).to.contain('app-1');
+    expect(result.stdout).to.contain('Test Private App');
+    expect(result.stdout).to.contain('app-2');
+    expect(result.stdout).to.contain('Test Management App');
+    expect(applicationsListStub.calledOnce).to.be.true;
   });
 
-  describe('application actions', () => {
-    beforeEach(() => {
-      applicationsListStub.resolves(
-        createPaginatedResponse([applicationFixtures.private])
-      );
-    });
+  it('displays message when no applications found', async () => {
+    applicationsListStub.resolves(createPaginatedResponse([]));
 
-    it('shows application details as JSON', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+    const result = await runCommand(['applications']);
 
-      const result = await runCommand(['applications']);
+    expect(result.stdout).to.contain('No applications found');
+  });
 
-      expect(result.stdout).to.contain('"id": "app-1"');
-      expect(result.stdout).to.contain('"name": "Test Private App"');
-    });
+  it('supports pagination with --page flag', async () => {
+    applicationsListStub.resolves(createPaginatedResponse([]));
 
-    it('deletes application when confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(true);
-      applicationsDeleteStub.resolves();
+    await runCommand(['applications', '--page', '2']);
 
-      const result = await runCommand(['applications']);
+    expect(
+      applicationsListStub.calledWith(
+        sinon.match({ page: 2 })
+      )
+    ).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Application deleted successfully');
-      expect(applicationsDeleteStub.calledWith('app-1')).to.be.true;
-    });
+  it('supports --size flag', async () => {
+    applicationsListStub.resolves(createPaginatedResponse([]));
 
-    it('does not delete application when not confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(false);
+    await runCommand(['applications', '--size', '10']);
 
-      await runCommand(['applications']);
-
-      expect(applicationsDeleteStub.called).to.be.false;
-    });
+    expect(
+      applicationsListStub.calledWith(
+        sinon.match({ size: 10 })
+      )
+    ).to.be.true;
   });
 });

--- a/test/unit/commands/connections/stripe-forward/tokenize.test.ts
+++ b/test/unit/commands/connections/stripe-forward/tokenize.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('connections stripe-forward tokenize', () => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+
+    fetchStub.resolves({
+      ok: true,
+      json: sinon.stub().resolves({
+        id: 'tok_stripe_1',
+        object: 'token',
+      }),
+      text: sinon.stub().resolves(''),
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('tokenizes card data via stripe forward', async () => {
+    const result = await runCommand([
+      'connections:stripe-forward:tokenize',
+      '--data',
+      '{"number":"4242424242424242","exp_month":12,"exp_year":2025}',
+    ]);
+
+    expect(result.stdout).to.contain('tok_stripe_1');
+    expect(fetchStub.calledOnce).to.be.true;
+    const [url, options] = fetchStub.firstCall.args;
+
+    expect(url).to.contain('/connections/stripe-forward/tokenize');
+    expect(options.method).to.equal('POST');
+    expect(options.headers['BT-API-KEY']).to.equal('test_management_key');
+    expect(options.headers['Content-Type']).to.equal('application/json');
+  });
+
+  it('requires data or file flag', async () => {
+    const result = await runCommand([
+      'connections:stripe-forward:tokenize',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided.'
+    );
+  });
+
+  it('handles API errors', async () => {
+    fetchStub.resolves({
+      ok: false,
+      status: 400,
+      text: sinon.stub().resolves('Bad Request'),
+    });
+
+    const result = await runCommand([
+      'connections:stripe-forward:tokenize',
+      '--data',
+      '{"number":"invalid"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('400');
+  });
+});

--- a/test/unit/commands/connections/stripe-forward/tokenize.test.ts
+++ b/test/unit/commands/connections/stripe-forward/tokenize.test.ts
@@ -40,9 +40,7 @@ describe('connections stripe-forward tokenize', () => {
   });
 
   it('requires data or file flag', async () => {
-    const result = await runCommand([
-      'connections:stripe-forward:tokenize',
-    ]);
+    const result = await runCommand(['connections:stripe-forward:tokenize']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain(

--- a/test/unit/commands/detokenize.test.ts
+++ b/test/unit/commands/detokenize.test.ts
@@ -33,7 +33,10 @@ describe('detokenize', () => {
     expect(tokensDetokenizeStub.calledOnce).to.be.true;
     const [input] = tokensDetokenizeStub.firstCall.args;
 
-    expect(input).to.deep.equal({ token_id: 'tok-123' });
+    expect(input).to.deep.equal({
+      // eslint-disable-next-line camelcase
+      token_id: 'tok-123',
+    });
   });
 
   it('requires --data or --file flag', async () => {

--- a/test/unit/commands/detokenize.test.ts
+++ b/test/unit/commands/detokenize.test.ts
@@ -1,0 +1,67 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../helpers/run-command';
+
+describe('detokenize', () => {
+  let tokensDetokenizeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensDetokenizeStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      detokenize: tokensDetokenizeStub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('detokenizes data with --data flag', async () => {
+    const detokenizeResult = { secret: 'revealed-value' };
+
+    tokensDetokenizeStub.resolves(detokenizeResult);
+
+    const result = await runCommand([
+      'detokenize',
+      '--data',
+      '{"token_id":"tok-123"}',
+    ]);
+
+    expect(result.stdout).to.contain('revealed-value');
+    expect(tokensDetokenizeStub.calledOnce).to.be.true;
+    const [input] = tokensDetokenizeStub.firstCall.args;
+
+    expect(input).to.deep.equal({ token_id: 'tok-123' });
+  });
+
+  it('requires --data or --file flag', async () => {
+    const result = await runCommand(['detokenize']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided.'
+    );
+  });
+
+  it('handles invalid JSON in --data flag', async () => {
+    const result = await runCommand(['detokenize', '--data', 'not-json']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Invalid JSON');
+  });
+
+  it('handles API errors', async () => {
+    tokensDetokenizeStub.rejects(new Error('Detokenize failed'));
+
+    const result = await runCommand([
+      'detokenize',
+      '--data',
+      '{"token_id":"tok-123"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Detokenize failed');
+  });
+});

--- a/test/unit/commands/documents/delete.test.ts
+++ b/test/unit/commands/documents/delete.test.ts
@@ -29,11 +29,7 @@ describe('documents delete', () => {
   });
 
   it('accepts --force flag', async () => {
-    const result = await runCommand([
-      'documents:delete',
-      'doc-123',
-      '--force',
-    ]);
+    const result = await runCommand(['documents:delete', 'doc-123', '--force']);
 
     expect(result.stdout).to.contain('Document deleted successfully!');
     expect(deleteStub.calledOnce).to.be.true;

--- a/test/unit/commands/documents/delete.test.ts
+++ b/test/unit/commands/documents/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('documents delete', () => {
-  let confirmStub: sinon.SinonStub;
   let deleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     deleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'documents').get(() => ({
@@ -17,48 +14,30 @@ describe('documents delete', () => {
     }));
 
     deleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes document without confirmation prompt', async () => {
-      const result = await runCommand([
-        'documents:delete',
-        'doc-123',
-        '--force',
-      ]);
+  it('deletes document', async () => {
+    const result = await runCommand(['documents:delete', 'doc-123']);
 
-      expect(result.stdout).to.contain('Document deleted successfully!');
-      expect(deleteStub.calledOnce).to.be.true;
-      expect(deleteStub.calledWith('doc-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Document deleted successfully!');
+    expect(deleteStub.calledOnce).to.be.true;
+    expect(deleteStub.calledWith('doc-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes document when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'documents:delete',
+      'doc-123',
+      '--force',
+    ]);
 
-      const result = await runCommand(['documents:delete', 'doc-123']);
-
-      expect(result.stdout).to.contain('Document deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(deleteStub.calledOnce).to.be.true;
-    });
-
-    it('does not delete document when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['documents:delete', 'doc-123']);
-
-      expect(result.stdout).to.not.contain('Document deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(deleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Document deleted successfully!');
+    expect(deleteStub.calledOnce).to.be.true;
+    expect(deleteStub.calledWith('doc-123')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/documents/delete.test.ts
+++ b/test/unit/commands/documents/delete.test.ts
@@ -1,0 +1,87 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('documents delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let deleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    deleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'documents').get(() => ({
+      delete: deleteStub,
+    }));
+
+    deleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes document without confirmation prompt', async () => {
+      const result = await runCommand([
+        'documents:delete',
+        'doc-123',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Document deleted successfully!');
+      expect(deleteStub.calledOnce).to.be.true;
+      expect(deleteStub.calledWith('doc-123')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes document when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['documents:delete', 'doc-123']);
+
+      expect(result.stdout).to.contain('Document deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(deleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete document when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['documents:delete', 'doc-123']);
+
+      expect(result.stdout).to.not.contain('Document deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(deleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires document id argument', async () => {
+      const result = await runCommand(['documents:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      deleteStub.rejects(new Error('Document not found'));
+
+      const result = await runCommand([
+        'documents:delete',
+        'doc-123',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Document not found');
+    });
+  });
+});

--- a/test/unit/commands/documents/download.test.ts
+++ b/test/unit/commands/documents/download.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, unlinkSync } from 'fs';
-import { resolve } from 'path';
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
@@ -23,10 +23,14 @@ describe('documents download', () => {
 
     dataGetStub.resolves({
       bodyUsed: false,
-      arrayBuffer: sinon.stub().resolves(contentBuffer.buffer.slice(
-        contentBuffer.byteOffset,
-        contentBuffer.byteOffset + contentBuffer.byteLength
-      )),
+      arrayBuffer: sinon
+        .stub()
+        .resolves(
+          contentBuffer.buffer.slice(
+            contentBuffer.byteOffset,
+            contentBuffer.byteOffset + contentBuffer.byteLength
+          )
+        ),
     });
   });
 

--- a/test/unit/commands/documents/download.test.ts
+++ b/test/unit/commands/documents/download.test.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('documents download', () => {
+  let dataGetStub: sinon.SinonStub;
+  const testContent = 'test document content';
+  const outputPath = resolve(process.cwd(), 'test-download-output.tmp');
+
+  beforeEach(() => {
+    dataGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'documents').get(() => ({
+      data: {
+        get: dataGetStub,
+      },
+    }));
+
+    const contentBuffer = Buffer.from(testContent);
+
+    dataGetStub.resolves({
+      bodyUsed: false,
+      arrayBuffer: sinon.stub().resolves(contentBuffer.buffer.slice(
+        contentBuffer.byteOffset,
+        contentBuffer.byteOffset + contentBuffer.byteLength
+      )),
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+
+    if (existsSync(outputPath)) {
+      unlinkSync(outputPath);
+    }
+  });
+
+  it('downloads a document to stdout', async () => {
+    const result = await runCommand(['documents:download', 'doc-123']);
+
+    expect(dataGetStub.calledOnce).to.be.true;
+    expect(dataGetStub.firstCall.args[0]).to.equal('doc-123');
+    expect(result.stdout).to.contain(testContent);
+  });
+
+  it('downloads a document to file with --output', async () => {
+    const result = await runCommand([
+      'documents:download',
+      'doc-123',
+      '--output',
+      outputPath,
+    ]);
+
+    expect(dataGetStub.calledOnce).to.be.true;
+    expect(result.stdout).to.contain(`Document downloaded to ${outputPath}`);
+    expect(existsSync(outputPath)).to.be.true;
+
+    const content = readFileSync(outputPath, 'utf-8');
+
+    expect(content).to.equal(testContent);
+  });
+
+  it('requires document id argument', async () => {
+    const result = await runCommand(['documents:download']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    dataGetStub.rejects(new Error('Document not found'));
+
+    const result = await runCommand(['documents:download', 'doc-123']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Document not found');
+  });
+});

--- a/test/unit/commands/documents/get.test.ts
+++ b/test/unit/commands/documents/get.test.ts
@@ -1,0 +1,48 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { documentFixtures } from '../../fixtures/documents';
+import { runCommand } from '../../helpers/run-command';
+
+describe('documents get', () => {
+  let getStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'documents').get(() => ({
+      get: getStub,
+    }));
+
+    getStub.resolves(documentFixtures.basic);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a document by ID', async () => {
+    const result = await runCommand(['documents:get', 'doc-123']);
+
+    expect(getStub.calledOnce).to.be.true;
+    expect(getStub.firstCall.args[0]).to.equal('doc-123');
+    expect(result.stdout).to.contain(documentFixtures.basic.id);
+    expect(result.stdout).to.contain('test-document.pdf');
+  });
+
+  it('requires document id argument', async () => {
+    const result = await runCommand(['documents:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    getStub.rejects(new Error('Document not found'));
+
+    const result = await runCommand(['documents:get', 'doc-123']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Document not found');
+  });
+});

--- a/test/unit/commands/documents/upload.test.ts
+++ b/test/unit/commands/documents/upload.test.ts
@@ -55,7 +55,10 @@ describe('documents upload', () => {
     const uploadArg = uploadStub.firstCall.args[0];
 
     expect(uploadArg.request).to.deep.equal({
-      metadata: { category: 'reports', owner: 'test-user' },
+      metadata: {
+        category: 'reports',
+        owner: 'test-user',
+      },
     });
     expect(result.stdout).to.contain('Document uploaded successfully!');
   });

--- a/test/unit/commands/documents/upload.test.ts
+++ b/test/unit/commands/documents/upload.test.ts
@@ -1,0 +1,82 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { documentFixtures } from '../../fixtures/documents';
+import { runCommand } from '../../helpers/run-command';
+
+describe('documents upload', () => {
+  let uploadStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    uploadStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'documents').get(() => ({
+      upload: uploadStub,
+    }));
+
+    uploadStub.resolves(documentFixtures.basic);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('uploads a document', async () => {
+    const result = await runCommand([
+      'documents:upload',
+      '--file',
+      'package.json',
+    ]);
+
+    expect(uploadStub.calledOnce).to.be.true;
+
+    const uploadArg = uploadStub.firstCall.args[0];
+
+    expect(uploadArg.document).to.be.instanceOf(Buffer);
+    expect(result.stdout).to.contain('Document uploaded successfully!');
+    expect(result.stdout).to.contain(documentFixtures.basic.id);
+  });
+
+  it('uploads a document with metadata', async () => {
+    uploadStub.resolves(documentFixtures.withMetadata);
+
+    const result = await runCommand([
+      'documents:upload',
+      '--file',
+      'package.json',
+      '--metadata',
+      'category=reports',
+      '--metadata',
+      'owner=test-user',
+    ]);
+
+    expect(uploadStub.calledOnce).to.be.true;
+
+    const uploadArg = uploadStub.firstCall.args[0];
+
+    expect(uploadArg.request).to.deep.equal({
+      metadata: { category: 'reports', owner: 'test-user' },
+    });
+    expect(result.stdout).to.contain('Document uploaded successfully!');
+  });
+
+  it('requires --file flag', async () => {
+    const result = await runCommand(['documents:upload']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles upload errors', async () => {
+    uploadStub.rejects(new Error('Upload failed'));
+
+    const result = await runCommand([
+      'documents:upload',
+      '--file',
+      'package.json',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Upload failed');
+  });
+});

--- a/test/unit/commands/enrichments/bank-account-verify.test.ts
+++ b/test/unit/commands/enrichments/bank-account-verify.test.ts
@@ -1,0 +1,77 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { enrichmentFixtures } from '../../fixtures/enrichments';
+import { runCommand } from '../../helpers/run-command';
+
+describe('enrichments bank-account-verify', () => {
+  let bankAccountVerifyStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    bankAccountVerifyStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'enrichments').get(() => ({
+      bankAccountVerify: bankAccountVerifyStub,
+    }));
+
+    bankAccountVerifyStub.resolves(enrichmentFixtures.bankVerification);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('verifies a bank account', async () => {
+    const result = await runCommand([
+      'enrichments:bank-account-verify',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.stdout).to.contain('verified');
+    expect(bankAccountVerifyStub.calledOnce).to.be.true;
+    const [request] = bankAccountVerifyStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+    expect(request.countryCode).to.equal('US');
+  });
+
+  it('passes optional flags', async () => {
+    const result = await runCommand([
+      'enrichments:bank-account-verify',
+      '--token-id',
+      'tok-1',
+      '--country-code',
+      'CA',
+      '--routing-number',
+      '021000021',
+    ]);
+
+    expect(result.stdout).to.contain('verified');
+    const [request] = bankAccountVerifyStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+    expect(request.countryCode).to.equal('CA');
+    expect(request.routingNumber).to.equal('021000021');
+  });
+
+  it('requires token-id flag', async () => {
+    const result = await runCommand(['enrichments:bank-account-verify']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    bankAccountVerifyStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'enrichments:bank-account-verify',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/google-pay/create.test.ts
+++ b/test/unit/commands/google-pay/create.test.ts
@@ -1,0 +1,82 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayCreateResponseFixture } from '../../fixtures/google-pay';
+import { runCommand } from '../../helpers/run-command';
+
+describe('google-pay create', () => {
+  let googlePayCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    googlePayCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      create: googlePayCreateStub,
+    }));
+
+    googlePayCreateStub.resolves(googlePayCreateResponseFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a google pay token with --data', async () => {
+    const paymentData = JSON.stringify({ token: 'abc' });
+
+    const result = await runCommand([
+      'google-pay:create',
+      '--data',
+      paymentData,
+    ]);
+
+    expect(result.stdout).to.contain('gp-1');
+    expect(googlePayCreateStub.calledOnce).to.be.true;
+    expect(
+      googlePayCreateStub.firstCall.args[0].googlePaymentData
+    ).to.deep.equal({ token: 'abc' });
+  });
+
+  it('passes expires-at and merchant-registration-id', async () => {
+    const paymentData = JSON.stringify({ token: 'abc' });
+
+    await runCommand([
+      'google-pay:create',
+      '--data',
+      paymentData,
+      '--expires-at',
+      '2025-12-31',
+      '--merchant-registration-id',
+      'mr-1',
+    ]);
+
+    expect(googlePayCreateStub.firstCall.args[0].expiresAt).to.equal(
+      '2025-12-31'
+    );
+    expect(
+      googlePayCreateStub.firstCall.args[0].merchantRegistrationId
+    ).to.equal('mr-1');
+  });
+
+  it('requires --data or --file', async () => {
+    const result = await runCommand(['google-pay:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided'
+    );
+  });
+
+  it('handles API errors', async () => {
+    googlePayCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'google-pay:create',
+      '--data',
+      '{"token":"abc"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/google-pay/delete.test.ts
+++ b/test/unit/commands/google-pay/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('google-pay delete', () => {
-  let confirmStub: sinon.SinonStub;
   let googlePayDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     googlePayDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
@@ -17,59 +14,39 @@ describe('google-pay delete', () => {
     }));
 
     googlePayDeleteStub.resolves('deleted');
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand(['google-pay:delete', 'gp-1', '--force']);
+  it('deletes google pay token', async () => {
+    const result = await runCommand(['google-pay:delete', 'gp-1']);
 
-      expect(result.stdout).to.contain(
-        'Google Pay token deleted successfully!'
-      );
-      expect(googlePayDeleteStub.calledOnce).to.be.true;
-      expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['google-pay:delete', 'gp-1', '-f']);
-
-      expect(result.stdout).to.contain(
-        'Google Pay token deleted successfully!'
-      );
-      expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay token deleted successfully!'
+    );
+    expect(googlePayDeleteStub.calledOnce).to.be.true;
+    expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['google-pay:delete', 'gp-1', '--force']);
 
-      const result = await runCommand(['google-pay:delete', 'gp-1']);
+    expect(result.stdout).to.contain(
+      'Google Pay token deleted successfully!'
+    );
+    expect(googlePayDeleteStub.calledOnce).to.be.true;
+    expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain(
-        'Google Pay token deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(googlePayDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['google-pay:delete', 'gp-1', '-f']);
 
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['google-pay:delete', 'gp-1']);
-
-      expect(result.stdout).to.not.contain(
-        'Google Pay token deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(googlePayDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay token deleted successfully!'
+    );
+    expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/google-pay/delete.test.ts
+++ b/test/unit/commands/google-pay/delete.test.ts
@@ -26,11 +26,7 @@ describe('google-pay delete', () => {
 
   describe('with --force flag', () => {
     it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'google-pay:delete',
-        'gp-1',
-        '--force',
-      ]);
+      const result = await runCommand(['google-pay:delete', 'gp-1', '--force']);
 
       expect(result.stdout).to.contain(
         'Google Pay token deleted successfully!'
@@ -89,11 +85,7 @@ describe('google-pay delete', () => {
     it('handles API errors', async () => {
       googlePayDeleteStub.rejects(new Error('Not found'));
 
-      const result = await runCommand([
-        'google-pay:delete',
-        'gp-1',
-        '--force',
-      ]);
+      const result = await runCommand(['google-pay:delete', 'gp-1', '--force']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Not found');

--- a/test/unit/commands/google-pay/delete.test.ts
+++ b/test/unit/commands/google-pay/delete.test.ts
@@ -23,9 +23,7 @@ describe('google-pay delete', () => {
   it('deletes google pay token', async () => {
     const result = await runCommand(['google-pay:delete', 'gp-1']);
 
-    expect(result.stdout).to.contain(
-      'Google Pay token deleted successfully!'
-    );
+    expect(result.stdout).to.contain('Google Pay token deleted successfully!');
     expect(googlePayDeleteStub.calledOnce).to.be.true;
     expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
   });
@@ -33,9 +31,7 @@ describe('google-pay delete', () => {
   it('accepts --force flag', async () => {
     const result = await runCommand(['google-pay:delete', 'gp-1', '--force']);
 
-    expect(result.stdout).to.contain(
-      'Google Pay token deleted successfully!'
-    );
+    expect(result.stdout).to.contain('Google Pay token deleted successfully!');
     expect(googlePayDeleteStub.calledOnce).to.be.true;
     expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
   });
@@ -43,9 +39,7 @@ describe('google-pay delete', () => {
   it('accepts -f shorthand flag', async () => {
     const result = await runCommand(['google-pay:delete', 'gp-1', '-f']);
 
-    expect(result.stdout).to.contain(
-      'Google Pay token deleted successfully!'
-    );
+    expect(result.stdout).to.contain('Google Pay token deleted successfully!');
     expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
   });
 

--- a/test/unit/commands/google-pay/delete.test.ts
+++ b/test/unit/commands/google-pay/delete.test.ts
@@ -1,0 +1,102 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('google-pay delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let googlePayDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    googlePayDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      delete: googlePayDeleteStub,
+    }));
+
+    googlePayDeleteStub.resolves('deleted');
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'google-pay:delete',
+        'gp-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Google Pay token deleted successfully!'
+      );
+      expect(googlePayDeleteStub.calledOnce).to.be.true;
+      expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['google-pay:delete', 'gp-1', '-f']);
+
+      expect(result.stdout).to.contain(
+        'Google Pay token deleted successfully!'
+      );
+      expect(googlePayDeleteStub.calledWith('gp-1')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['google-pay:delete', 'gp-1']);
+
+      expect(result.stdout).to.contain(
+        'Google Pay token deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(googlePayDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['google-pay:delete', 'gp-1']);
+
+      expect(result.stdout).to.not.contain(
+        'Google Pay token deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(googlePayDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires id argument', async () => {
+      const result = await runCommand(['google-pay:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      googlePayDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'google-pay:delete',
+        'gp-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/google-pay/get.test.ts
+++ b/test/unit/commands/google-pay/get.test.ts
@@ -1,0 +1,47 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayTokenFixture } from '../../fixtures/google-pay';
+import { runCommand } from '../../helpers/run-command';
+
+describe('google-pay get', () => {
+  let googlePayGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    googlePayGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      get: googlePayGetStub,
+    }));
+
+    googlePayGetStub.resolves(googlePayTokenFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a google pay token by id', async () => {
+    const result = await runCommand(['google-pay:get', 'gp-1']);
+
+    expect(result.stdout).to.contain('gp-1');
+    expect(googlePayGetStub.calledOnce).to.be.true;
+    expect(googlePayGetStub.calledWith('gp-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['google-pay:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    googlePayGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand(['google-pay:get', 'gp-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/google-pay/merchants/certificates/create.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/create.test.ts
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayMerchantCertificatesFixture } from '../../../../fixtures/google-pay';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('google-pay merchants certificates create', () => {
+  let certificatesCreateStub: sinon.SinonStub;
+  let readFileSyncStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    certificatesCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        certificates: {
+          create: certificatesCreateStub,
+        },
+      },
+    }));
+
+    certificatesCreateStub.resolves(googlePayMerchantCertificatesFixture);
+
+    readFileSyncStub = sinon.stub(fs, 'readFileSync');
+    readFileSyncStub.returns(Buffer.from('cert-data'));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates certificates', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert',
+      '/path/to/merchant.p12',
+      '--merchant-cert-password',
+      'pass1',
+    ]);
+
+    expect(result.stdout).to.contain('cert-1');
+    expect(certificatesCreateStub.calledOnce).to.be.true;
+    expect(certificatesCreateStub.firstCall.args[0]).to.equal('merch-1');
+    expect(
+      certificatesCreateStub.firstCall.args[1].merchantCertificateData
+    ).to.equal(Buffer.from('cert-data').toString('base64'));
+    expect(
+      certificatesCreateStub.firstCall.args[1].merchantCertificatePassword
+    ).to.equal('pass1');
+  });
+
+  it('requires merchant-id argument', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:create',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('requires --merchant-cert flag', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert-password',
+      'pass1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    certificatesCreateStub.rejects(new Error('Certificate error'));
+
+    const result = await runCommand([
+      'google-pay:merchants:certificates:create',
+      'merch-1',
+      '--merchant-cert',
+      '/path/to/merchant.p12',
+      '--merchant-cert-password',
+      'pass1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Certificate error');
+  });
+});

--- a/test/unit/commands/google-pay/merchants/certificates/create.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/create.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
+import fs from 'fs';
 import sinon from 'sinon';
 import { googlePayMerchantCertificatesFixture } from '../../../../fixtures/google-pay';
 import { runCommand } from '../../../../helpers/run-command';

--- a/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
@@ -41,8 +41,7 @@ describe('google-pay merchants certificates delete', () => {
         'Google Pay merchant certificate deleted successfully!'
       );
       expect(certificatesDeleteStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be
-        .true;
+      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
       expect(confirmStub.called).to.be.false;
     });
   });

--- a/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
@@ -1,0 +1,110 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('google-pay merchants certificates delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let certificatesDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    certificatesDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        certificates: {
+          delete: certificatesDeleteStub,
+        },
+      },
+    }));
+
+    certificatesDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'google-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Google Pay merchant certificate deleted successfully!'
+      );
+      expect(certificatesDeleteStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be
+        .true;
+      expect(confirmStub.called).to.be.false;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'google-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Google Pay merchant certificate deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'google-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+      ]);
+
+      expect(result.stdout).to.not.contain(
+        'Google Pay merchant certificate deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(certificatesDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires merchant-id and certificate-id arguments', async () => {
+      const result = await runCommand([
+        'google-pay:merchants:certificates:delete',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 2 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      certificatesDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'google-pay:merchants:certificates:delete',
+        'merch-1',
+        'cert-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../../helpers/run-command';
 
 describe('google-pay merchants certificates delete', () => {
-  let confirmStub: sinon.SinonStub;
   let certificatesDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     certificatesDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
@@ -21,63 +18,39 @@ describe('google-pay merchants certificates delete', () => {
     }));
 
     certificatesDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'google-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-        '--force',
-      ]);
+  it('deletes google pay merchant certificate', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:delete',
+      'merch-1',
+      'cert-1',
+    ]);
 
-      expect(result.stdout).to.contain(
-        'Google Pay merchant certificate deleted successfully!'
-      );
-      expect(certificatesDeleteStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay merchant certificate deleted successfully!'
+    );
+    expect(certificatesDeleteStub.calledOnce).to.be.true;
+    expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:delete',
+      'merch-1',
+      'cert-1',
+      '--force',
+    ]);
 
-      const result = await runCommand([
-        'google-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-      ]);
-
-      expect(result.stdout).to.contain(
-        'Google Pay merchant certificate deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.calledOnce).to.be.true;
-    });
-
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand([
-        'google-pay:merchants:certificates:delete',
-        'merch-1',
-        'cert-1',
-      ]);
-
-      expect(result.stdout).to.not.contain(
-        'Google Pay merchant certificate deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(certificatesDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay merchant certificate deleted successfully!'
+    );
+    expect(certificatesDeleteStub.calledOnce).to.be.true;
+    expect(certificatesDeleteStub.calledWith('merch-1', 'cert-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/google-pay/merchants/certificates/get.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/get.test.ts
@@ -38,9 +38,7 @@ describe('google-pay merchants certificates get', () => {
   });
 
   it('requires merchant-id and certificate-id arguments', async () => {
-    const result = await runCommand([
-      'google-pay:merchants:certificates:get',
-    ]);
+    const result = await runCommand(['google-pay:merchants:certificates:get']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain('Missing 2 required arg');

--- a/test/unit/commands/google-pay/merchants/certificates/get.test.ts
+++ b/test/unit/commands/google-pay/merchants/certificates/get.test.ts
@@ -1,0 +1,71 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayMerchantCertificatesFixture } from '../../../../fixtures/google-pay';
+import { runCommand } from '../../../../helpers/run-command';
+
+describe('google-pay merchants certificates get', () => {
+  let certificatesGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    certificatesGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        certificates: {
+          get: certificatesGetStub,
+        },
+      },
+    }));
+
+    certificatesGetStub.resolves(googlePayMerchantCertificatesFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets certificates by merchant and certificate id', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:get',
+      'merch-1',
+      'cert-1',
+    ]);
+
+    expect(result.stdout).to.contain('cert-1');
+    expect(certificatesGetStub.calledOnce).to.be.true;
+    expect(certificatesGetStub.calledWith('merch-1', 'cert-1')).to.be.true;
+  });
+
+  it('requires merchant-id and certificate-id arguments', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:get',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 2 required arg');
+  });
+
+  it('requires certificate-id argument', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:certificates:get',
+      'merch-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    certificatesGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand([
+      'google-pay:merchants:certificates:get',
+      'merch-1',
+      'cert-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/google-pay/merchants/create.test.ts
+++ b/test/unit/commands/google-pay/merchants/create.test.ts
@@ -33,9 +33,9 @@ describe('google-pay merchants create', () => {
     expect(result.stdout).to.contain('merch-1');
     expect(result.stdout).to.contain('merchant.com.example');
     expect(merchantCreateStub.calledOnce).to.be.true;
-    expect(
-      merchantCreateStub.firstCall.args[0].merchantIdentifier
-    ).to.equal('merchant.com.example');
+    expect(merchantCreateStub.firstCall.args[0].merchantIdentifier).to.equal(
+      'merchant.com.example'
+    );
   });
 
   it('requires --merchant-identifier flag', async () => {

--- a/test/unit/commands/google-pay/merchants/create.test.ts
+++ b/test/unit/commands/google-pay/merchants/create.test.ts
@@ -1,0 +1,60 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayMerchantFixture } from '../../../fixtures/google-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('google-pay merchants create', () => {
+  let merchantCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    merchantCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        create: merchantCreateStub,
+      },
+    }));
+
+    merchantCreateStub.resolves(googlePayMerchantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a merchant', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:create',
+      '--merchant-identifier',
+      'merchant.com.example',
+    ]);
+
+    expect(result.stdout).to.contain('merch-1');
+    expect(result.stdout).to.contain('merchant.com.example');
+    expect(merchantCreateStub.calledOnce).to.be.true;
+    expect(
+      merchantCreateStub.firstCall.args[0].merchantIdentifier
+    ).to.equal('merchant.com.example');
+  });
+
+  it('requires --merchant-identifier flag', async () => {
+    const result = await runCommand(['google-pay:merchants:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    merchantCreateStub.rejects(new Error('Creation failed'));
+
+    const result = await runCommand([
+      'google-pay:merchants:create',
+      '--merchant-identifier',
+      'merchant.com.example',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Creation failed');
+  });
+});

--- a/test/unit/commands/google-pay/merchants/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/delete.test.ts
@@ -1,0 +1,101 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('google-pay merchants delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let merchantDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    merchantDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        delete: merchantDeleteStub,
+      },
+    }));
+
+    merchantDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes without confirmation prompt', async () => {
+      const result = await runCommand([
+        'google-pay:merchants:delete',
+        'merch-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Google Pay merchant deleted successfully!'
+      );
+      expect(merchantDeleteStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'google-pay:merchants:delete',
+        'merch-1',
+      ]);
+
+      expect(result.stdout).to.contain(
+        'Google Pay merchant deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'google-pay:merchants:delete',
+        'merch-1',
+      ]);
+
+      expect(result.stdout).to.not.contain(
+        'Google Pay merchant deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(merchantDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires id argument', async () => {
+      const result = await runCommand(['google-pay:merchants:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      merchantDeleteStub.rejects(new Error('Not found'));
+
+      const result = await runCommand([
+        'google-pay:merchants:delete',
+        'merch-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Not found');
+    });
+  });
+});

--- a/test/unit/commands/google-pay/merchants/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/delete.test.ts
@@ -23,10 +23,7 @@ describe('google-pay merchants delete', () => {
   });
 
   it('deletes google pay merchant', async () => {
-    const result = await runCommand([
-      'google-pay:merchants:delete',
-      'merch-1',
-    ]);
+    const result = await runCommand(['google-pay:merchants:delete', 'merch-1']);
 
     expect(result.stdout).to.contain(
       'Google Pay merchant deleted successfully!'

--- a/test/unit/commands/google-pay/merchants/delete.test.ts
+++ b/test/unit/commands/google-pay/merchants/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('google-pay merchants delete', () => {
-  let confirmStub: sinon.SinonStub;
   let merchantDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     merchantDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
@@ -19,60 +16,37 @@ describe('google-pay merchants delete', () => {
     }));
 
     merchantDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes without confirmation prompt', async () => {
-      const result = await runCommand([
-        'google-pay:merchants:delete',
-        'merch-1',
-        '--force',
-      ]);
+  it('deletes google pay merchant', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:delete',
+      'merch-1',
+    ]);
 
-      expect(result.stdout).to.contain(
-        'Google Pay merchant deleted successfully!'
-      );
-      expect(merchantDeleteStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay merchant deleted successfully!'
+    );
+    expect(merchantDeleteStub.calledOnce).to.be.true;
+    expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'google-pay:merchants:delete',
+      'merch-1',
+      '--force',
+    ]);
 
-      const result = await runCommand([
-        'google-pay:merchants:delete',
-        'merch-1',
-      ]);
-
-      expect(result.stdout).to.contain(
-        'Google Pay merchant deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.calledOnce).to.be.true;
-    });
-
-    it('does not delete when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand([
-        'google-pay:merchants:delete',
-        'merch-1',
-      ]);
-
-      expect(result.stdout).to.not.contain(
-        'Google Pay merchant deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(merchantDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain(
+      'Google Pay merchant deleted successfully!'
+    );
+    expect(merchantDeleteStub.calledOnce).to.be.true;
+    expect(merchantDeleteStub.calledWith('merch-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/google-pay/merchants/get.test.ts
+++ b/test/unit/commands/google-pay/merchants/get.test.ts
@@ -1,0 +1,53 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { googlePayMerchantFixture } from '../../../fixtures/google-pay';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('google-pay merchants get', () => {
+  let merchantGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    merchantGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'googlePay').get(() => ({
+      merchant: {
+        get: merchantGetStub,
+      },
+    }));
+
+    merchantGetStub.resolves(googlePayMerchantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a merchant by id', async () => {
+    const result = await runCommand(['google-pay:merchants:get', 'merch-1']);
+
+    expect(result.stdout).to.contain('merch-1');
+    expect(result.stdout).to.contain('merchant.com.example');
+    expect(merchantGetStub.calledOnce).to.be.true;
+    expect(merchantGetStub.calledWith('merch-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['google-pay:merchants:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    merchantGetStub.rejects(new Error('Not found'));
+
+    const result = await runCommand([
+      'google-pay:merchants:get',
+      'merch-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Not found');
+  });
+});

--- a/test/unit/commands/keys/create.test.ts
+++ b/test/unit/commands/keys/create.test.ts
@@ -1,0 +1,54 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { keyResponseFixture } from '../../fixtures/keys';
+import { runCommand } from '../../helpers/run-command';
+
+describe('keys create', () => {
+  let keysCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    keysCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'keys').get(() => ({
+      create: keysCreateStub,
+    }));
+
+    keysCreateStub.resolves(keyResponseFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a key', async () => {
+    const result = await runCommand(['keys:create']);
+
+    expect(result.stdout).to.contain('Key created successfully!');
+    expect(result.stdout).to.contain('key-new');
+    expect(keysCreateStub.calledOnce).to.be.true;
+  });
+
+  it('creates a key with expires-at flag', async () => {
+    const result = await runCommand([
+      'keys:create',
+      '--expires-at',
+      '2025-12-31',
+    ]);
+
+    expect(result.stdout).to.contain('Key created successfully!');
+    expect(keysCreateStub.calledOnce).to.be.true;
+    const [request] = keysCreateStub.firstCall.args;
+
+    expect(request.expiresAt).to.deep.equal(new Date('2025-12-31'));
+  });
+
+  it('handles API errors', async () => {
+    keysCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['keys:create']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/keys/delete.test.ts
+++ b/test/unit/commands/keys/delete.test.ts
@@ -26,11 +26,7 @@ describe('keys delete', () => {
 
   describe('with --force flag', () => {
     it('deletes key without confirmation prompt', async () => {
-      const result = await runCommand([
-        'keys:delete',
-        'key-1',
-        '--force',
-      ]);
+      const result = await runCommand(['keys:delete', 'key-1', '--force']);
 
       expect(result.stdout).to.contain('Key deleted successfully!');
       expect(keysDeleteStub.calledOnce).to.be.true;
@@ -81,11 +77,7 @@ describe('keys delete', () => {
     it('handles API errors', async () => {
       keysDeleteStub.rejects(new Error('Key not found'));
 
-      const result = await runCommand([
-        'keys:delete',
-        'key-1',
-        '--force',
-      ]);
+      const result = await runCommand(['keys:delete', 'key-1', '--force']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Key not found');

--- a/test/unit/commands/keys/delete.test.ts
+++ b/test/unit/commands/keys/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('keys delete', () => {
-  let confirmStub: sinon.SinonStub;
   let keysDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     keysDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'keys').get(() => ({
@@ -17,51 +14,33 @@ describe('keys delete', () => {
     }));
 
     keysDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes key without confirmation prompt', async () => {
-      const result = await runCommand(['keys:delete', 'key-1', '--force']);
+  it('deletes key', async () => {
+    const result = await runCommand(['keys:delete', 'key-1']);
 
-      expect(result.stdout).to.contain('Key deleted successfully!');
-      expect(keysDeleteStub.calledOnce).to.be.true;
-      expect(keysDeleteStub.calledWith('key-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['keys:delete', 'key-1', '-f']);
-
-      expect(result.stdout).to.contain('Key deleted successfully!');
-      expect(keysDeleteStub.calledWith('key-1')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Key deleted successfully!');
+    expect(keysDeleteStub.calledOnce).to.be.true;
+    expect(keysDeleteStub.calledWith('key-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes key when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['keys:delete', 'key-1', '--force']);
 
-      const result = await runCommand(['keys:delete', 'key-1']);
+    expect(result.stdout).to.contain('Key deleted successfully!');
+    expect(keysDeleteStub.calledOnce).to.be.true;
+    expect(keysDeleteStub.calledWith('key-1')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Key deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(keysDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['keys:delete', 'key-1', '-f']);
 
-    it('does not delete key when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['keys:delete', 'key-1']);
-
-      expect(result.stdout).to.not.contain('Key deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(keysDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Key deleted successfully!');
+    expect(keysDeleteStub.calledWith('key-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/keys/delete.test.ts
+++ b/test/unit/commands/keys/delete.test.ts
@@ -1,0 +1,94 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('keys delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let keysDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    keysDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'keys').get(() => ({
+      delete: keysDeleteStub,
+    }));
+
+    keysDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes key without confirmation prompt', async () => {
+      const result = await runCommand([
+        'keys:delete',
+        'key-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Key deleted successfully!');
+      expect(keysDeleteStub.calledOnce).to.be.true;
+      expect(keysDeleteStub.calledWith('key-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['keys:delete', 'key-1', '-f']);
+
+      expect(result.stdout).to.contain('Key deleted successfully!');
+      expect(keysDeleteStub.calledWith('key-1')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes key when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['keys:delete', 'key-1']);
+
+      expect(result.stdout).to.contain('Key deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(keysDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete key when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['keys:delete', 'key-1']);
+
+      expect(result.stdout).to.not.contain('Key deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(keysDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires key id argument', async () => {
+      const result = await runCommand(['keys:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      keysDeleteStub.rejects(new Error('Key not found'));
+
+      const result = await runCommand([
+        'keys:delete',
+        'key-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Key not found');
+    });
+  });
+});

--- a/test/unit/commands/keys/index.test.ts
+++ b/test/unit/commands/keys/index.test.ts
@@ -1,0 +1,48 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { keyMetadataFixtures } from '../../fixtures/keys';
+import { runCommand } from '../../helpers/run-command';
+
+describe('keys', () => {
+  let keysListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    keysListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'keys').get(() => ({
+      list: keysListStub,
+    }));
+
+    keysListStub.resolves(keyMetadataFixtures);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists keys', async () => {
+    const result = await runCommand(['keys']);
+
+    expect(result.stdout).to.contain('key-1');
+    expect(result.stdout).to.contain('key-2');
+    expect(keysListStub.calledOnce).to.be.true;
+  });
+
+  it('handles empty results', async () => {
+    keysListStub.resolves([]);
+
+    const result = await runCommand(['keys']);
+
+    expect(result.stdout).to.contain('No keys found.');
+  });
+
+  it('handles API errors', async () => {
+    keysListStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['keys']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/logs/entity-types.test.ts
+++ b/test/unit/commands/logs/entity-types.test.ts
@@ -1,0 +1,50 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { entityTypeFixtures } from '../../fixtures/logs';
+import { runCommand } from '../../helpers/run-command';
+
+describe('logs entity-types', () => {
+  let getEntityTypesStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getEntityTypesStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'logs').get(() => ({
+      getEntityTypes: getEntityTypesStub,
+    }));
+
+    getEntityTypesStub.resolves(entityTypeFixtures);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists entity types', async () => {
+    const result = await runCommand(['logs:entity-types']);
+
+    expect(result.stdout).to.contain('Application');
+    expect(result.stdout).to.contain('application');
+    expect(result.stdout).to.contain('Token');
+    expect(result.stdout).to.contain('token');
+    expect(getEntityTypesStub.calledOnce).to.be.true;
+  });
+
+  it('handles empty results', async () => {
+    getEntityTypesStub.resolves([]);
+
+    const result = await runCommand(['logs:entity-types']);
+
+    expect(result.stdout).to.contain('No entity types found.');
+  });
+
+  it('handles API errors', async () => {
+    getEntityTypesStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['logs:entity-types']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/logs/index.test.ts
+++ b/test/unit/commands/logs/index.test.ts
@@ -1,0 +1,74 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { logFixtures } from '../../fixtures/logs';
+import { runCommand } from '../../helpers/run-command';
+
+describe('logs', () => {
+  let logsListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    logsListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'logs').get(() => ({
+      list: logsListStub,
+    }));
+
+    logsListStub.resolves({ data: logFixtures });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists audit logs', async () => {
+    const result = await runCommand(['logs']);
+
+    expect(result.stdout).to.contain('application');
+    expect(result.stdout).to.contain('token');
+    expect(result.stdout).to.contain('e1');
+    expect(result.stdout).to.contain('read');
+    expect(result.stdout).to.contain('Token retrieved');
+    expect(logsListStub.calledOnce).to.be.true;
+  });
+
+  it('passes filter flags to SDK', async () => {
+    const result = await runCommand([
+      'logs',
+      '--entity-type',
+      'token',
+      '--entity-id',
+      'e1',
+      '--start-date',
+      '2024-01-01',
+      '--end-date',
+      '2024-12-31',
+    ]);
+
+    expect(result.error).to.not.exist;
+    expect(logsListStub.calledOnce).to.be.true;
+    const [request] = logsListStub.firstCall.args;
+
+    expect(request.entityType).to.equal('token');
+    expect(request.entityId).to.equal('e1');
+    expect(request.startDate).to.deep.equal(new Date('2024-01-01'));
+    expect(request.endDate).to.deep.equal(new Date('2024-12-31'));
+  });
+
+  it('handles empty results', async () => {
+    logsListStub.resolves({ data: [] });
+
+    const result = await runCommand(['logs']);
+
+    expect(result.stdout).to.contain('No logs found.');
+  });
+
+  it('handles API errors', async () => {
+    logsListStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['logs']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/network-tokens/create.test.ts
+++ b/test/unit/commands/network-tokens/create.test.ts
@@ -1,0 +1,80 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { networkTokenFixtures } from '../../fixtures/network-tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens create', () => {
+  let networkTokensCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    networkTokensCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      create: networkTokensCreateStub,
+    }));
+
+    networkTokensCreateStub.resolves(networkTokenFixtures.networkToken1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a network token with token-id', async () => {
+    const result = await runCommand([
+      'network-tokens:create',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.stdout).to.contain('nt-1');
+    expect(networkTokensCreateStub.calledOnce).to.be.true;
+    const [request] = networkTokensCreateStub.firstCall.args;
+
+    expect(request.tokenId).to.equal('tok-1');
+  });
+
+  it('creates a network token with token-intent-id', async () => {
+    const result = await runCommand([
+      'network-tokens:create',
+      '--token-intent-id',
+      'ti-1',
+    ]);
+
+    expect(result.stdout).to.contain('nt-1');
+    const [request] = networkTokensCreateStub.firstCall.args;
+
+    expect(request.tokenIntentId).to.equal('ti-1');
+  });
+
+  it('creates a network token with data', async () => {
+    const result = await runCommand([
+      'network-tokens:create',
+      '--data',
+      '{"number":"4242424242424242","expirationMonth":12,"expirationYear":2025}',
+    ]);
+
+    expect(result.stdout).to.contain('nt-1');
+    const [request] = networkTokensCreateStub.firstCall.args;
+
+    expect(request.data).to.deep.equal({
+      number: '4242424242424242',
+      expirationMonth: 12,
+      expirationYear: 2025,
+    });
+  });
+
+  it('handles API errors', async () => {
+    networkTokensCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'network-tokens:create',
+      '--token-id',
+      'tok-1',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/network-tokens/cryptogram.test.ts
+++ b/test/unit/commands/network-tokens/cryptogram.test.ts
@@ -1,0 +1,51 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { networkTokenFixtures } from '../../fixtures/network-tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens cryptogram', () => {
+  let networkTokensCryptogramStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    networkTokensCryptogramStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      cryptogram: networkTokensCryptogramStub,
+    }));
+
+    networkTokensCryptogramStub.resolves(networkTokenFixtures.cryptogram);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a cryptogram by network token id', async () => {
+    const result = await runCommand(['network-tokens:cryptogram', 'nt-1']);
+
+    expect(result.stdout).to.contain('abc123cryptogram');
+    expect(result.stdout).to.contain('05');
+    expect(networkTokensCryptogramStub.calledOnce).to.be.true;
+    expect(networkTokensCryptogramStub.calledWith('nt-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['network-tokens:cryptogram']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    networkTokensCryptogramStub.rejects(new Error('Network token not found'));
+
+    const result = await runCommand([
+      'network-tokens:cryptogram',
+      'nt-invalid',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Network token not found');
+  });
+});

--- a/test/unit/commands/network-tokens/delete.test.ts
+++ b/test/unit/commands/network-tokens/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('network-tokens delete', () => {
-  let confirmStub: sinon.SinonStub;
   let networkTokensDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     networkTokensDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
@@ -17,57 +14,37 @@ describe('network-tokens delete', () => {
     }));
 
     networkTokensDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes network token without confirmation prompt', async () => {
-      const result = await runCommand([
-        'network-tokens:delete',
-        'nt-1',
-        '--force',
-      ]);
+  it('deletes network token', async () => {
+    const result = await runCommand(['network-tokens:delete', 'nt-1']);
 
-      expect(result.stdout).to.contain('Network token deleted successfully!');
-      expect(networkTokensDeleteStub.calledOnce).to.be.true;
-      expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['network-tokens:delete', 'nt-1', '-f']);
-
-      expect(result.stdout).to.contain('Network token deleted successfully!');
-      expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Network token deleted successfully!');
+    expect(networkTokensDeleteStub.calledOnce).to.be.true;
+    expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes network token when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'network-tokens:delete',
+      'nt-1',
+      '--force',
+    ]);
 
-      const result = await runCommand(['network-tokens:delete', 'nt-1']);
+    expect(result.stdout).to.contain('Network token deleted successfully!');
+    expect(networkTokensDeleteStub.calledOnce).to.be.true;
+    expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Network token deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(networkTokensDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['network-tokens:delete', 'nt-1', '-f']);
 
-    it('does not delete network token when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['network-tokens:delete', 'nt-1']);
-
-      expect(result.stdout).to.not.contain(
-        'Network token deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(networkTokensDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Network token deleted successfully!');
+    expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/network-tokens/delete.test.ts
+++ b/test/unit/commands/network-tokens/delete.test.ts
@@ -1,0 +1,96 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let networkTokensDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    networkTokensDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      delete: networkTokensDeleteStub,
+    }));
+
+    networkTokensDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes network token without confirmation prompt', async () => {
+      const result = await runCommand([
+        'network-tokens:delete',
+        'nt-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Network token deleted successfully!');
+      expect(networkTokensDeleteStub.calledOnce).to.be.true;
+      expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['network-tokens:delete', 'nt-1', '-f']);
+
+      expect(result.stdout).to.contain('Network token deleted successfully!');
+      expect(networkTokensDeleteStub.calledWith('nt-1')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes network token when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['network-tokens:delete', 'nt-1']);
+
+      expect(result.stdout).to.contain('Network token deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(networkTokensDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete network token when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['network-tokens:delete', 'nt-1']);
+
+      expect(result.stdout).to.not.contain(
+        'Network token deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(networkTokensDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires network token id argument', async () => {
+      const result = await runCommand(['network-tokens:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      networkTokensDeleteStub.rejects(new Error('Network token not found'));
+
+      const result = await runCommand([
+        'network-tokens:delete',
+        'nt-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Network token not found');
+    });
+  });
+});

--- a/test/unit/commands/network-tokens/get.test.ts
+++ b/test/unit/commands/network-tokens/get.test.ts
@@ -1,0 +1,47 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { networkTokenFixtures } from '../../fixtures/network-tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens get', () => {
+  let networkTokensGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    networkTokensGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      get: networkTokensGetStub,
+    }));
+
+    networkTokensGetStub.resolves(networkTokenFixtures.networkToken1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a network token by id', async () => {
+    const result = await runCommand(['network-tokens:get', 'nt-1']);
+
+    expect(result.stdout).to.contain('nt-1');
+    expect(networkTokensGetStub.calledOnce).to.be.true;
+    expect(networkTokensGetStub.calledWith('nt-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['network-tokens:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    networkTokensGetStub.rejects(new Error('Network token not found'));
+
+    const result = await runCommand(['network-tokens:get', 'nt-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Network token not found');
+  });
+});

--- a/test/unit/commands/network-tokens/resume.test.ts
+++ b/test/unit/commands/network-tokens/resume.test.ts
@@ -1,0 +1,47 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { networkTokenFixtures } from '../../fixtures/network-tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens resume', () => {
+  let networkTokensResumeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    networkTokensResumeStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      resume: networkTokensResumeStub,
+    }));
+
+    networkTokensResumeStub.resolves(networkTokenFixtures.networkToken1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('resumes a network token', async () => {
+    const result = await runCommand(['network-tokens:resume', 'nt-1']);
+
+    expect(result.stdout).to.contain('nt-1');
+    expect(networkTokensResumeStub.calledOnce).to.be.true;
+    expect(networkTokensResumeStub.calledWith('nt-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['network-tokens:resume']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    networkTokensResumeStub.rejects(new Error('Network token not found'));
+
+    const result = await runCommand(['network-tokens:resume', 'nt-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Network token not found');
+  });
+});

--- a/test/unit/commands/network-tokens/suspend.test.ts
+++ b/test/unit/commands/network-tokens/suspend.test.ts
@@ -1,0 +1,51 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { networkTokenFixtures } from '../../fixtures/network-tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('network-tokens suspend', () => {
+  let networkTokensSuspendStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    networkTokensSuspendStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'networkTokens').get(() => ({
+      suspend: networkTokensSuspendStub,
+    }));
+
+    networkTokensSuspendStub.resolves({
+      ...networkTokenFixtures.networkToken1,
+      status: 'suspended',
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('suspends a network token', async () => {
+    const result = await runCommand(['network-tokens:suspend', 'nt-1']);
+
+    expect(result.stdout).to.contain('nt-1');
+    expect(result.stdout).to.contain('suspended');
+    expect(networkTokensSuspendStub.calledOnce).to.be.true;
+    expect(networkTokensSuspendStub.calledWith('nt-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['network-tokens:suspend']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    networkTokensSuspendStub.rejects(new Error('Network token not found'));
+
+    const result = await runCommand(['network-tokens:suspend', 'nt-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Network token not found');
+  });
+});

--- a/test/unit/commands/proxies/create.test.ts
+++ b/test/unit/commands/proxies/create.test.ts
@@ -1,26 +1,16 @@
 import { BasisTheoryClient, BasisTheoryError } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as files from '../../../../src/files';
 import { proxyFixtures } from '../../fixtures/proxies';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('proxies create', () => {
-  let inputStub: PromptStub;
-  let confirmStub: PromptStub;
-  let selectStub: PromptStub;
   let readFileStub: sinon.SinonStub;
   let proxiesCreateStub: sinon.SinonStub;
   let proxiesGetStub: sinon.SinonStub;
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    confirmStub = new PromptStub(sinon.stub(confirm, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
     readFileStub = sinon.stub(files, 'readFileContents');
     proxiesCreateStub = sinon.stub();
     proxiesGetStub = sinon.stub();
@@ -33,7 +23,6 @@ describe('proxies create', () => {
     proxiesCreateStub.resolves(proxyFixtures.active);
     proxiesGetStub.resolves(proxyFixtures.active);
     readFileStub.returns('module.exports = async (req) => req;');
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
@@ -115,6 +104,10 @@ describe('proxies create', () => {
         'Test Proxy',
         '--destination-url',
         'https://example.com/api',
+        '--request-transform-code',
+        './request.js',
+        '--request-transform-image',
+        'node-bt',
         '--application-id',
         'app-123',
       ]);
@@ -253,33 +246,6 @@ describe('proxies create', () => {
     });
 
     it('creates proxy with response transform runtime flags', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Request Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Response transform: Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          'Response transform: (Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          'Response transform: (Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      confirmStub.resolves(true);
-
       const result = await runCommand([
         'proxies:create',
         '--name',
@@ -311,36 +277,6 @@ describe('proxies create', () => {
     });
 
     it('waits for proxy to be ready by default for node22 transform', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      confirmStub.resolves(true);
       proxiesCreateStub.resolves({
         ...proxyFixtures.creating,
         id: 'proxy-wait',
@@ -366,36 +302,6 @@ describe('proxies create', () => {
     });
 
     it('skips waiting when --async flag is set', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      confirmStub.resolves(true);
       proxiesCreateStub.resolves({
         ...proxyFixtures.active,
         id: 'proxy-async',
@@ -421,195 +327,7 @@ describe('proxies create', () => {
     });
   });
 
-  describe('with prompts', () => {
-    it('prompts for name and destination-url when not provided', async () => {
-      inputStub
-        .onCallResolves('What is the Proxy name?', 'Prompted Proxy')
-        .onCallResolves(
-          'What is the Proxy destination URL?',
-          'https://example.com/api'
-        )
-        .onCallResolves(
-          '(Optional) Enter the Request Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        );
-      confirmStub.resolves(true);
-
-      const result = await runCommand(['proxies:create']);
-
-      expect(result.stdout).to.contain('Proxy created successfully!');
-      expect(proxiesCreateStub.firstCall.args[0].name).to.equal(
-        'Prompted Proxy'
-      );
-      inputStub.verifyExpectations();
-      confirmStub.expectCalledWith(
-        'Does the Proxy require Basis Theory authentication?'
-      );
-    });
-
-    it('only prompts for missing fields', async () => {
-      inputStub
-        .onCallResolves(
-          'What is the Proxy destination URL?',
-          'https://example.com/api'
-        )
-        .onCallResolves(
-          '(Optional) Enter the Request Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        );
-      confirmStub.resolves(true);
-
-      const result = await runCommand([
-        'proxies:create',
-        '--name',
-        'Test Proxy',
-      ]);
-
-      expect(result.stdout).to.contain('Proxy created successfully!');
-      expect(proxiesCreateStub.firstCall.args[0].name).to.equal('Test Proxy');
-
-      // Name was provided via flag, so should NOT prompt for it
-      inputStub.expectNotCalledWith('What is the Proxy name?');
-      inputStub.verifyExpectations();
-    });
-
-    it('prompts for request transform runtime options when code and node22 image provided', async () => {
-      inputStub
-        .onCallResolves('What is the Proxy name?', 'Prompted Proxy')
-        .onCallResolves(
-          'What is the Proxy destination URL?',
-          'https://example.com/api'
-        )
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Timeout in seconds (1-30, press Enter for default: 10):',
-          '20'
-        )
-        .onCallResolves(
-          'Request transform: Warm concurrency (0-1, press Enter for default: 0):',
-          '1'
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      confirmStub.resolves(true);
-      selectStub.onCallResolves('Request transform: Resource tier:', 'large');
-
-      const result = await runCommand([
-        'proxies:create',
-        '--request-transform-code',
-        './request.js',
-        '--request-transform-image',
-        'node22',
-      ]);
-
-      expect(result.stdout).to.contain('Proxy created successfully!');
-      const [createArg] = proxiesCreateStub.firstCall.args;
-
-      expect(createArg.requestTransforms[0].options.runtime.image).to.equal(
-        'node22'
-      );
-      expect(createArg.requestTransforms[0].options.runtime.timeout).to.equal(
-        20
-      );
-      expect(
-        createArg.requestTransforms[0].options.runtime.warmConcurrency
-      ).to.equal(1);
-      expect(createArg.requestTransforms[0].options.runtime.resources).to.equal(
-        'large'
-      );
-    });
-  });
-
   describe('validation', () => {
-    it('prompts for request-transform-image when code provided without image', async () => {
-      selectStub.onCallResolves(
-        'Which runtime do you want for the request transform?',
-        'node-bt'
-      );
-      confirmStub.resolves(true);
-
-      const result = await runCommand([
-        'proxies:create',
-        '--name',
-        'Test Proxy',
-        '--destination-url',
-        'https://example.com/api',
-        '--request-transform-code',
-        './request.js',
-      ]);
-
-      expect(result.error).to.not.exist;
-      expect(result.stdout).to.contain('Proxy created successfully!');
-      selectStub.expectCalledWith(
-        'Which runtime do you want for the request transform?'
-      );
-    });
-
-    it('prompts for response-transform-image when code provided without image', async () => {
-      selectStub.onCallResolves(
-        'Which runtime do you want for the response transform?',
-        'node-bt'
-      );
-      confirmStub.resolves(true);
-
-      const result = await runCommand([
-        'proxies:create',
-        '--name',
-        'Test Proxy',
-        '--destination-url',
-        'https://example.com/api',
-        '--response-transform-code',
-        './response.js',
-      ]);
-
-      expect(result.error).to.not.exist;
-      expect(result.stdout).to.contain('Proxy created successfully!');
-      selectStub.expectCalledWith(
-        'Which runtime do you want for the response transform?'
-      );
-    });
-
     it('errors when --request-transform-timeout used with node-bt', async () => {
       const result = await runCommand([
         'proxies:create',
@@ -674,16 +392,6 @@ describe('proxies create', () => {
     });
 
     it('allows --application-id when at least one transform is legacy', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        );
-      confirmStub.resolves(true);
       proxiesCreateStub.resolves(proxyFixtures.active);
 
       const result = await runCommand([
@@ -705,24 +413,6 @@ describe('proxies create', () => {
     });
 
     it('does not wait when no node22 transform is configured', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Request Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        );
-      confirmStub.resolves(true);
       proxiesCreateStub.resolves(proxyFixtures.active);
 
       const result = await runCommand([
@@ -735,6 +425,17 @@ describe('proxies create', () => {
 
       expect(result.stdout).to.contain('Proxy created successfully!');
       expect(proxiesGetStub.called).to.be.false;
+    });
+
+    it('errors when --destination-url is not provided', async () => {
+      const result = await runCommand([
+        'proxies:create',
+        '--name',
+        'Test Proxy',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('--destination-url is required');
     });
   });
 
@@ -790,32 +491,6 @@ describe('proxies create', () => {
     });
 
     it('errors when dependencies file contains invalid JSON', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the Response Transform code file path:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Proxy:',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          'Request transform: (Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      confirmStub.resolves(true);
       readFileStub.withArgs('./invalid.json').returns('not valid json');
 
       const result = await runCommand([

--- a/test/unit/commands/proxies/delete.test.ts
+++ b/test/unit/commands/proxies/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('proxies delete', () => {
-  let confirmStub: sinon.SinonStub;
   let proxiesDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     proxiesDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'proxies').get(() => ({
@@ -17,51 +14,33 @@ describe('proxies delete', () => {
     }));
 
     proxiesDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --yes flag', () => {
-    it('deletes proxy without confirmation prompt', async () => {
-      const result = await runCommand(['proxies:delete', 'proxy-123', '--yes']);
+  it('deletes proxy', async () => {
+    const result = await runCommand(['proxies:delete', 'proxy-123']);
 
-      expect(result.stdout).to.contain('Proxy deleted successfully!');
-      expect(proxiesDeleteStub.calledOnce).to.be.true;
-      expect(proxiesDeleteStub.calledWith('proxy-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -y shorthand flag', async () => {
-      const result = await runCommand(['proxies:delete', 'proxy-456', '-y']);
-
-      expect(result.stdout).to.contain('Proxy deleted successfully!');
-      expect(proxiesDeleteStub.calledWith('proxy-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Proxy deleted successfully!');
+    expect(proxiesDeleteStub.calledOnce).to.be.true;
+    expect(proxiesDeleteStub.calledWith('proxy-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes proxy when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --yes flag', async () => {
+    const result = await runCommand(['proxies:delete', 'proxy-123', '--yes']);
 
-      const result = await runCommand(['proxies:delete', 'proxy-123']);
+    expect(result.stdout).to.contain('Proxy deleted successfully!');
+    expect(proxiesDeleteStub.calledOnce).to.be.true;
+    expect(proxiesDeleteStub.calledWith('proxy-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Proxy deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(proxiesDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -y shorthand flag', async () => {
+    const result = await runCommand(['proxies:delete', 'proxy-456', '-y']);
 
-    it('does not delete proxy when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['proxies:delete', 'proxy-123']);
-
-      expect(result.stdout).to.not.contain('Proxy deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(proxiesDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Proxy deleted successfully!');
+    expect(proxiesDeleteStub.calledWith('proxy-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/proxies/index.test.ts
+++ b/test/unit/commands/proxies/index.test.ts
@@ -1,34 +1,20 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { createProxyList } from '../../fixtures/proxies';
 import { createPaginatedResponse } from '../../helpers/pagination';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('proxies list', () => {
-  let inputStub: PromptStub;
-  let selectStub: PromptStub;
-  let confirmStub: PromptStub;
   let proxiesListStub: sinon.SinonStub;
-  let proxiesDeleteStub: sinon.SinonStub;
 
-  // List with unique IDs for list tests
   const listFixtures = createProxyList(['active', 'withTransforms']);
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
-    confirmStub = new PromptStub(sinon.stub(confirm, 'default'));
     proxiesListStub = sinon.stub();
-    proxiesDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'proxies').get(() => ({
       list: proxiesListStub,
-      delete: proxiesDeleteStub,
     }));
   });
 
@@ -36,78 +22,47 @@ describe('proxies list', () => {
     sinon.restore();
   });
 
-  describe('listing proxies', () => {
-    it('displays proxies and shows details when selected', async () => {
-      proxiesListStub.resolves(createPaginatedResponse(listFixtures));
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+  it('displays proxies in a table', async () => {
+    proxiesListStub.resolves(createPaginatedResponse(listFixtures));
 
-      const result = await runCommand(['proxies']);
+    const result = await runCommand(['proxies']);
 
-      expect(result.stdout).to.contain(listFixtures[0].id);
-      expect(result.stdout).to.contain(listFixtures[0].name);
-      expect(proxiesListStub.calledOnce).to.be.true;
-      inputStub.verifyExpectations();
-      selectStub.verifyExpectations();
-    });
-
-    it('displays message when no proxies found', async () => {
-      proxiesListStub.resolves(createPaginatedResponse([]));
-
-      const result = await runCommand(['proxies']);
-
-      expect(result.stdout).to.contain('No proxies found');
-    });
-
-    it('supports pagination with --page flag', async () => {
-      proxiesListStub.resolves(createPaginatedResponse([]));
-
-      await runCommand(['proxies', '--page', '2']);
-
-      expect(
-        proxiesListStub.calledWith({
-          size: 5,
-          page: 2,
-        })
-      ).to.be.true;
-    });
+    expect(result.stdout).to.contain(listFixtures[0].id);
+    expect(result.stdout).to.contain(listFixtures[0].name);
+    expect(result.stdout).to.contain(listFixtures[1].id);
+    expect(result.stdout).to.contain(listFixtures[1].name);
+    expect(proxiesListStub.calledOnce).to.be.true;
   });
 
-  describe('proxy actions', () => {
-    beforeEach(() => {
-      proxiesListStub.resolves(createPaginatedResponse([listFixtures[0]]));
-    });
+  it('displays message when no proxies found', async () => {
+    proxiesListStub.resolves(createPaginatedResponse([]));
 
-    it('shows proxy details as JSON', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+    const result = await runCommand(['proxies']);
 
-      const result = await runCommand(['proxies']);
+    expect(result.stdout).to.contain('No proxies found');
+  });
 
-      expect(result.stdout).to.contain(`"id": "${listFixtures[0].id}"`);
-      expect(result.stdout).to.contain(`"name": "${listFixtures[0].name}"`);
-    });
+  it('supports pagination with --page flag', async () => {
+    proxiesListStub.resolves(createPaginatedResponse([]));
 
-    it('deletes proxy when confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(true);
-      proxiesDeleteStub.resolves();
+    await runCommand(['proxies', '--page', '2']);
 
-      const result = await runCommand(['proxies']);
+    expect(
+      proxiesListStub.calledWith(
+        sinon.match({ page: 2 })
+      )
+    ).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Proxy deleted successfully');
-      expect(proxiesDeleteStub.calledWith(listFixtures[0].id)).to.be.true;
-    });
+  it('supports --size flag', async () => {
+    proxiesListStub.resolves(createPaginatedResponse([]));
 
-    it('does not delete proxy when not confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(false);
+    await runCommand(['proxies', '--size', '10']);
 
-      await runCommand(['proxies']);
-
-      expect(proxiesDeleteStub.called).to.be.false;
-    });
+    expect(
+      proxiesListStub.calledWith(
+        sinon.match({ size: 10 })
+      )
+    ).to.be.true;
   });
 });

--- a/test/unit/commands/proxies/index.test.ts
+++ b/test/unit/commands/proxies/index.test.ts
@@ -47,11 +47,7 @@ describe('proxies list', () => {
 
     await runCommand(['proxies', '--page', '2']);
 
-    expect(
-      proxiesListStub.calledWith(
-        sinon.match({ page: 2 })
-      )
-    ).to.be.true;
+    expect(proxiesListStub.calledWith(sinon.match({ page: 2 }))).to.be.true;
   });
 
   it('supports --size flag', async () => {
@@ -59,10 +55,6 @@ describe('proxies list', () => {
 
     await runCommand(['proxies', '--size', '10']);
 
-    expect(
-      proxiesListStub.calledWith(
-        sinon.match({ size: 10 })
-      )
-    ).to.be.true;
+    expect(proxiesListStub.calledWith(sinon.match({ size: 10 }))).to.be.true;
   });
 });

--- a/test/unit/commands/proxies/invoke.test.ts
+++ b/test/unit/commands/proxies/invoke.test.ts
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('proxies invoke', () => {
+  let fetchStub: sinon.SinonStub;
+
+  const proxyResponse = { result: 'success', data: { key: 'value' } };
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+
+    fetchStub.resolves(
+      new Response(JSON.stringify(proxyResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('invokes proxy with --proxy-key', async () => {
+    const result = await runCommand([
+      'proxies:invoke',
+      '--proxy-key',
+      'proxy-key-123',
+      '--data',
+      '{"key": "value"}',
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+
+    const [url, options] = fetchStub.firstCall.args;
+
+    expect(url).to.equal('https://api.basistheory.com/proxy');
+    expect(options.method).to.equal('POST');
+    expect(options.headers['BT-PROXY-KEY']).to.equal('proxy-key-123');
+    expect(options.headers['BT-API-KEY']).to.equal('test_management_key');
+    expect(options.body).to.equal('{"key":"value"}');
+    expect(result.stdout).to.contain('success');
+  });
+
+  it('invokes proxy with --proxy-url', async () => {
+    const result = await runCommand([
+      'proxies:invoke',
+      '--proxy-url',
+      'https://example.com/api',
+      '--data',
+      '{"key": "value"}',
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+
+    const [, options] = fetchStub.firstCall.args;
+
+    expect(options.headers['BT-PROXY-URL']).to.equal(
+      'https://example.com/api'
+    );
+    expect(result.stdout).to.contain('success');
+  });
+
+  it('invokes proxy with custom method', async () => {
+    await runCommand([
+      'proxies:invoke',
+      '--proxy-key',
+      'proxy-key-123',
+      '--method',
+      'GET',
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+
+    const [, options] = fetchStub.firstCall.args;
+
+    expect(options.method).to.equal('GET');
+  });
+
+  it('appends path to proxy endpoint', async () => {
+    await runCommand([
+      'proxies:invoke',
+      '--proxy-key',
+      'proxy-key-123',
+      '--path',
+      'users/123',
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+
+    const [url] = fetchStub.firstCall.args;
+
+    expect(url).to.equal('https://api.basistheory.com/proxy/users/123');
+  });
+
+  it('errors when neither --proxy-url nor --proxy-key provided', async () => {
+    const result = await runCommand([
+      'proxies:invoke',
+      '--data',
+      '{}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --proxy-url or --proxy-key must be provided'
+    );
+  });
+
+  it('handles proxy error responses', async () => {
+    fetchStub.resolves(
+      new Response('Bad Request', {
+        status: 400,
+      })
+    );
+
+    const result = await runCommand([
+      'proxies:invoke',
+      '--proxy-key',
+      'proxy-key-123',
+      '--data',
+      '{}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Proxy request failed [400]');
+  });
+});

--- a/test/unit/commands/proxies/invoke.test.ts
+++ b/test/unit/commands/proxies/invoke.test.ts
@@ -5,7 +5,12 @@ import { runCommand } from '../../helpers/run-command';
 describe('proxies invoke', () => {
   let fetchStub: sinon.SinonStub;
 
-  const proxyResponse = { result: 'success', data: { key: 'value' } };
+  const proxyResponse = {
+    result: 'success',
+    data: {
+      key: 'value',
+    },
+  };
 
   beforeEach(() => {
     fetchStub = sinon.stub(global, 'fetch');
@@ -56,9 +61,7 @@ describe('proxies invoke', () => {
 
     const [, options] = fetchStub.firstCall.args;
 
-    expect(options.headers['BT-PROXY-URL']).to.equal(
-      'https://example.com/api'
-    );
+    expect(options.headers['BT-PROXY-URL']).to.equal('https://example.com/api');
     expect(result.stdout).to.contain('success');
   });
 
@@ -95,11 +98,7 @@ describe('proxies invoke', () => {
   });
 
   it('errors when neither --proxy-url nor --proxy-key provided', async () => {
-    const result = await runCommand([
-      'proxies:invoke',
-      '--data',
-      '{}',
-    ]);
+    const result = await runCommand(['proxies:invoke', '--data', '{}']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain(

--- a/test/unit/commands/reactors/create.test.ts
+++ b/test/unit/commands/reactors/create.test.ts
@@ -1,23 +1,16 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as files from '../../../../src/files';
 import { reactorFixtures } from '../../fixtures/reactors';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('reactors create', () => {
-  let inputStub: PromptStub;
-  let selectStub: PromptStub;
   let readFileStub: sinon.SinonStub;
   let reactorsCreateStub: sinon.SinonStub;
   let reactorsGetStub: sinon.SinonStub;
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
     readFileStub = sinon.stub(files, 'readFileContents');
     reactorsCreateStub = sinon.stub();
     reactorsGetStub = sinon.stub();
@@ -100,29 +93,6 @@ describe('reactors create', () => {
 
   describe('with runtime flags', () => {
     it('creates reactor with --image node22 flag', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      selectStub.onCallResolves('Resource tier:', 'standard');
-
       const result = await runCommand([
         'reactors:create',
         '--name',
@@ -131,6 +101,8 @@ describe('reactors create', () => {
         './reactor.js',
         '--image',
         'node22',
+        '--resources',
+        'standard',
       ]);
 
       expect(result.stdout).to.contain('Reactor created successfully!');
@@ -225,27 +197,6 @@ describe('reactors create', () => {
     });
 
     it('waits for reactor to be ready by default for node22', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
       reactorsCreateStub.resolves({
         ...reactorFixtures.creating,
         id: 'reactor-wait',
@@ -269,27 +220,6 @@ describe('reactors create', () => {
     });
 
     it('skips waiting when --async flag is set', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
       reactorsCreateStub.resolves({
         ...reactorFixtures.active,
         id: 'reactor-async',
@@ -310,160 +240,6 @@ describe('reactors create', () => {
 
       expect(result.stdout).to.contain('Reactor created successfully!');
       expect(reactorsGetStub.called).to.be.false;
-    });
-  });
-
-  describe('with prompts', () => {
-    it('prompts for image first, then name and code', async () => {
-      selectStub.onCallResolves('Which runtime do you want to use?', 'node-bt');
-      inputStub
-        .onCallResolves('What is the Reactor name?', 'Prompted Reactor')
-        .onCallResolves('Enter the Reactor code file path:', './reactor.js')
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Reactor:',
-          ''
-        );
-
-      const result = await runCommand(['reactors:create']);
-
-      expect(result.stdout).to.contain('Reactor created successfully!');
-      expect(reactorsCreateStub.firstCall.args[0].name).to.equal(
-        'Prompted Reactor'
-      );
-      selectStub.verifyExpectations();
-      inputStub.verifyExpectations();
-    });
-
-    it('only prompts for missing fields', async () => {
-      inputStub
-        .onCallResolves('Enter the Reactor code file path:', './reactor.js')
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Reactor:',
-          ''
-        );
-
-      const result = await runCommand([
-        'reactors:create',
-        '--name',
-        'Test Reactor',
-        '--image',
-        'node-bt',
-      ]);
-
-      expect(result.stdout).to.contain('Reactor created successfully!');
-      expect(reactorsCreateStub.firstCall.args[0].name).to.equal(
-        'Test Reactor'
-      );
-
-      // Name was provided via flag, so should NOT prompt for it
-      inputStub.expectNotCalledWith('What is the Reactor name?');
-      // Image was provided via flag, so should NOT prompt for it
-      selectStub.expectNotCalledWith('Which runtime do you want to use?');
-      inputStub.verifyExpectations();
-    });
-
-    it('prompts for optional application-id when node-bt selected', async () => {
-      selectStub.onCallResolves('Which runtime do you want to use?', 'node-bt');
-      inputStub
-        .onCallResolves('What is the Reactor name?', 'Prompted Reactor')
-        .onCallResolves('Enter the Reactor code file path:', './reactor.js')
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Reactor:',
-          'app-456'
-        );
-
-      const result = await runCommand(['reactors:create']);
-
-      expect(result.stdout).to.contain('Reactor created successfully!');
-      expect(reactorsCreateStub.firstCall.args[0].application).to.deep.equal({
-        id: 'app-456',
-      });
-      selectStub.verifyExpectations();
-      inputStub.verifyExpectations();
-    });
-
-    it('prompts for node22 options when node22 selected', async () => {
-      selectStub
-        .onCallResolves('Which runtime do you want to use?', 'node22')
-        .onCallResolves('Resource tier:', 'large');
-      inputStub
-        .onCallResolves('What is the Reactor name?', 'Node22 Reactor')
-        .onCallResolves('Enter the Reactor code file path:', './reactor.js')
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          '20'
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          '1'
-        )
-        .onCallResolves(
-          '(Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-
-      const result = await runCommand(['reactors:create']);
-
-      expect(result.stdout).to.contain('Reactor created successfully!');
-      const [createArg] = reactorsCreateStub.firstCall.args;
-
-      expect(createArg.runtime.image).to.equal('node22');
-      expect(createArg.runtime.timeout).to.equal(20);
-      expect(createArg.runtime.warmConcurrency).to.equal(1);
-      expect(createArg.runtime.resources).to.equal('large');
-      // Application ID should not be prompted for node22
-      inputStub.expectNotCalledWith(
-        '(Optional) Enter the Application ID to use in the Reactor:'
-      );
-      inputStub.verifyExpectations();
-      selectStub.verifyExpectations();
-    });
-
-    it('skips node22 options when node-bt selected', async () => {
-      selectStub.onCallResolves('Which runtime do you want to use?', 'node-bt');
-      inputStub
-        .onCallResolves('What is the Reactor name?', 'Legacy Reactor')
-        .onCallResolves('Enter the Reactor code file path:', './reactor.js')
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Enter the Application ID to use in the Reactor:',
-          ''
-        );
-
-      const result = await runCommand(['reactors:create']);
-
-      expect(result.stdout).to.contain('Reactor created successfully!');
-      const [createArg] = reactorsCreateStub.firstCall.args;
-
-      expect(createArg.runtime).to.be.undefined;
-      // Should not have prompted for timeout, resources, etc.
-      inputStub.expectNotCalledWith(
-        'Timeout in seconds (1-30, press Enter for default: 10):'
-      );
-      selectStub.expectNotCalledWith('Resource tier:');
     });
   });
 
@@ -568,26 +344,6 @@ describe('reactors create', () => {
     });
 
     it('errors when --application-id used with node22', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default):',
-          ''
-        )
-        .onCallResolves('Warm concurrency (0-1, press Enter for default):', '')
-        .onCallResolves(
-          '(Optional) Runtime package.json file path (JSON format):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
-      selectStub.onCallResolves('Resource tier:', 'standard');
-
       const result = await runCommand([
         'reactors:create',
         '--name',
@@ -626,23 +382,6 @@ describe('reactors create', () => {
     });
 
     it('errors when dependencies file contains invalid JSON', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
       readFileStub.withArgs('./invalid.json').returns('not valid json');
 
       const result = await runCommand([
@@ -666,23 +405,6 @@ describe('reactors create', () => {
     });
 
     it('errors when dependencies file does not exist', async () => {
-      inputStub
-        .onCallResolves(
-          '(Optional) Enter the configuration file path (.env format):',
-          ''
-        )
-        .onCallResolves(
-          'Timeout in seconds (1-30, press Enter for default: 10):',
-          ''
-        )
-        .onCallResolves(
-          'Warm concurrency (0-1, press Enter for default: 0):',
-          ''
-        )
-        .onCallResolves(
-          '(Optional) Permissions (comma-separated, e.g. token:read, token:create):',
-          ''
-        );
       readFileStub
         .withArgs('./missing.json')
         .throws(new Error('ENOENT: no such file or directory'));

--- a/test/unit/commands/reactors/delete.test.ts
+++ b/test/unit/commands/reactors/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('reactors delete', () => {
-  let confirmStub: sinon.SinonStub;
   let reactorsDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     reactorsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'reactors').get(() => ({
@@ -17,55 +14,37 @@ describe('reactors delete', () => {
     }));
 
     reactorsDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --yes flag', () => {
-    it('deletes reactor without confirmation prompt', async () => {
-      const result = await runCommand([
-        'reactors:delete',
-        'reactor-123',
-        '--yes',
-      ]);
+  it('deletes reactor', async () => {
+    const result = await runCommand(['reactors:delete', 'reactor-123']);
 
-      expect(result.stdout).to.contain('Reactor deleted successfully!');
-      expect(reactorsDeleteStub.calledOnce).to.be.true;
-      expect(reactorsDeleteStub.calledWith('reactor-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -y shorthand flag', async () => {
-      const result = await runCommand(['reactors:delete', 'reactor-456', '-y']);
-
-      expect(result.stdout).to.contain('Reactor deleted successfully!');
-      expect(reactorsDeleteStub.calledWith('reactor-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Reactor deleted successfully!');
+    expect(reactorsDeleteStub.calledOnce).to.be.true;
+    expect(reactorsDeleteStub.calledWith('reactor-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes reactor when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --yes flag', async () => {
+    const result = await runCommand([
+      'reactors:delete',
+      'reactor-123',
+      '--yes',
+    ]);
 
-      const result = await runCommand(['reactors:delete', 'reactor-123']);
+    expect(result.stdout).to.contain('Reactor deleted successfully!');
+    expect(reactorsDeleteStub.calledOnce).to.be.true;
+    expect(reactorsDeleteStub.calledWith('reactor-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Reactor deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(reactorsDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -y shorthand flag', async () => {
+    const result = await runCommand(['reactors:delete', 'reactor-456', '-y']);
 
-    it('does not delete reactor when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['reactors:delete', 'reactor-123']);
-
-      expect(result.stdout).to.not.contain('Reactor deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(reactorsDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Reactor deleted successfully!');
+    expect(reactorsDeleteStub.calledWith('reactor-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/reactors/get-result.test.ts
+++ b/test/unit/commands/reactors/get-result.test.ts
@@ -1,0 +1,69 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('reactors get-result', () => {
+  let resultsGetStub: sinon.SinonStub;
+
+  const resultResponse = {
+    tokens: { token1: 'value1' },
+    raw: { key: 'raw_value' },
+  };
+
+  beforeEach(() => {
+    resultsGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'reactors').get(() => ({
+      results: {
+        get: resultsGetStub,
+      },
+    }));
+
+    resultsGetStub.resolves(resultResponse);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets async reactor result', async () => {
+    const result = await runCommand([
+      'reactors:get-result',
+      'reactor-123',
+      'request-456',
+    ]);
+
+    expect(resultsGetStub.calledOnce).to.be.true;
+    expect(resultsGetStub.firstCall.args[0]).to.equal('reactor-123');
+    expect(resultsGetStub.firstCall.args[1]).to.equal('request-456');
+    expect(result.stdout).to.contain('token1');
+  });
+
+  it('requires reactor id argument', async () => {
+    const result = await runCommand(['reactors:get-result']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 2 required args');
+  });
+
+  it('requires request-id argument', async () => {
+    const result = await runCommand(['reactors:get-result', 'reactor-123']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    resultsGetStub.rejects(new Error('Result not found'));
+
+    const result = await runCommand([
+      'reactors:get-result',
+      'reactor-123',
+      'request-456',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Result not found');
+  });
+});

--- a/test/unit/commands/reactors/index.test.ts
+++ b/test/unit/commands/reactors/index.test.ts
@@ -1,34 +1,20 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
-import * as input from '@inquirer/input';
-import * as select from '@inquirer/select';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { createReactorList } from '../../fixtures/reactors';
 import { createPaginatedResponse } from '../../helpers/pagination';
 import { runCommand } from '../../helpers/run-command';
-import { PromptStub } from '../../helpers/types';
 
 describe('reactors list', () => {
-  let inputStub: PromptStub;
-  let selectStub: PromptStub;
-  let confirmStub: PromptStub;
   let reactorsListStub: sinon.SinonStub;
-  let reactorsDeleteStub: sinon.SinonStub;
 
-  // List with unique IDs for list tests
   const listFixtures = createReactorList(['active', 'withApplication']);
 
   beforeEach(() => {
-    inputStub = new PromptStub(sinon.stub(input, 'default'));
-    selectStub = new PromptStub(sinon.stub(select, 'default'));
-    confirmStub = new PromptStub(sinon.stub(confirm, 'default'));
     reactorsListStub = sinon.stub();
-    reactorsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'reactors').get(() => ({
       list: reactorsListStub,
-      delete: reactorsDeleteStub,
     }));
   });
 
@@ -36,78 +22,47 @@ describe('reactors list', () => {
     sinon.restore();
   });
 
-  describe('listing reactors', () => {
-    it('displays reactors and shows details when selected', async () => {
-      reactorsListStub.resolves(createPaginatedResponse(listFixtures));
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+  it('displays reactors in a table', async () => {
+    reactorsListStub.resolves(createPaginatedResponse(listFixtures));
 
-      const result = await runCommand(['reactors']);
+    const result = await runCommand(['reactors']);
 
-      expect(result.stdout).to.contain(listFixtures[0].id);
-      expect(result.stdout).to.contain(listFixtures[0].name);
-      expect(reactorsListStub.calledOnce).to.be.true;
-      inputStub.verifyExpectations();
-      selectStub.verifyExpectations();
-    });
-
-    it('displays message when no reactors found', async () => {
-      reactorsListStub.resolves(createPaginatedResponse([]));
-
-      const result = await runCommand(['reactors']);
-
-      expect(result.stdout).to.contain('No reactors found');
-    });
-
-    it('supports pagination with --page flag', async () => {
-      reactorsListStub.resolves(createPaginatedResponse([]));
-
-      await runCommand(['reactors', '--page', '2']);
-
-      expect(
-        reactorsListStub.calledWith({
-          size: 5,
-          page: 2,
-        })
-      ).to.be.true;
-    });
+    expect(result.stdout).to.contain(listFixtures[0].id);
+    expect(result.stdout).to.contain(listFixtures[0].name);
+    expect(result.stdout).to.contain(listFixtures[1].id);
+    expect(result.stdout).to.contain(listFixtures[1].name);
+    expect(reactorsListStub.calledOnce).to.be.true;
   });
 
-  describe('reactor actions', () => {
-    beforeEach(() => {
-      reactorsListStub.resolves(createPaginatedResponse([listFixtures[0]]));
-    });
+  it('displays message when no reactors found', async () => {
+    reactorsListStub.resolves(createPaginatedResponse([]));
 
-    it('shows reactor details as JSON', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'details');
+    const result = await runCommand(['reactors']);
 
-      const result = await runCommand(['reactors']);
+    expect(result.stdout).to.contain('No reactors found');
+  });
 
-      expect(result.stdout).to.contain(`"id": "${listFixtures[0].id}"`);
-      expect(result.stdout).to.contain(`"name": "${listFixtures[0].name}"`);
-    });
+  it('supports pagination with --page flag', async () => {
+    reactorsListStub.resolves(createPaginatedResponse([]));
 
-    it('deletes reactor when confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(true);
-      reactorsDeleteStub.resolves();
+    await runCommand(['reactors', '--page', '2']);
 
-      const result = await runCommand(['reactors']);
+    expect(
+      reactorsListStub.calledWith(
+        sinon.match({ page: 2 })
+      )
+    ).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Reactor deleted successfully');
-      expect(reactorsDeleteStub.calledWith(listFixtures[0].id)).to.be.true;
-    });
+  it('supports --size flag', async () => {
+    reactorsListStub.resolves(createPaginatedResponse([]));
 
-    it('does not delete reactor when not confirmed', async () => {
-      inputStub.onCallResolves('Select one (#)', '1');
-      selectStub.onCallResolves('Select action to perform', 'delete');
-      confirmStub.resolves(false);
+    await runCommand(['reactors', '--size', '10']);
 
-      await runCommand(['reactors']);
-
-      expect(reactorsDeleteStub.called).to.be.false;
-    });
+    expect(
+      reactorsListStub.calledWith(
+        sinon.match({ size: 10 })
+      )
+    ).to.be.true;
   });
 });

--- a/test/unit/commands/reactors/index.test.ts
+++ b/test/unit/commands/reactors/index.test.ts
@@ -47,11 +47,7 @@ describe('reactors list', () => {
 
     await runCommand(['reactors', '--page', '2']);
 
-    expect(
-      reactorsListStub.calledWith(
-        sinon.match({ page: 2 })
-      )
-    ).to.be.true;
+    expect(reactorsListStub.calledWith(sinon.match({ page: 2 }))).to.be.true;
   });
 
   it('supports --size flag', async () => {
@@ -59,10 +55,6 @@ describe('reactors list', () => {
 
     await runCommand(['reactors', '--size', '10']);
 
-    expect(
-      reactorsListStub.calledWith(
-        sinon.match({ size: 10 })
-      )
-    ).to.be.true;
+    expect(reactorsListStub.calledWith(sinon.match({ size: 10 }))).to.be.true;
   });
 });

--- a/test/unit/commands/reactors/invoke-async.test.ts
+++ b/test/unit/commands/reactors/invoke-async.test.ts
@@ -41,10 +41,7 @@ describe('reactors invoke-async', () => {
   });
 
   it('invokes reactor asynchronously without body', async () => {
-    const result = await runCommand([
-      'reactors:invoke-async',
-      'reactor-123',
-    ]);
+    const result = await runCommand(['reactors:invoke-async', 'reactor-123']);
 
     expect(reactAsyncStub.calledOnce).to.be.true;
     expect(reactAsyncStub.firstCall.args[0]).to.equal('reactor-123');

--- a/test/unit/commands/reactors/invoke-async.test.ts
+++ b/test/unit/commands/reactors/invoke-async.test.ts
@@ -1,0 +1,75 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('reactors invoke-async', () => {
+  let reactAsyncStub: sinon.SinonStub;
+
+  const asyncResponse = {
+    asyncReactorRequestId: 'async-request-123',
+  };
+
+  beforeEach(() => {
+    reactAsyncStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'reactors').get(() => ({
+      reactAsync: reactAsyncStub,
+    }));
+
+    reactAsyncStub.resolves(asyncResponse);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('invokes reactor asynchronously with --data flag', async () => {
+    const data = JSON.stringify({ key: 'value' });
+
+    const result = await runCommand([
+      'reactors:invoke-async',
+      'reactor-123',
+      '--data',
+      data,
+    ]);
+
+    expect(reactAsyncStub.calledOnce).to.be.true;
+    expect(reactAsyncStub.firstCall.args[0]).to.equal('reactor-123');
+    expect(reactAsyncStub.firstCall.args[1]).to.deep.equal({ key: 'value' });
+    expect(result.stdout).to.contain('async-request-123');
+  });
+
+  it('invokes reactor asynchronously without body', async () => {
+    const result = await runCommand([
+      'reactors:invoke-async',
+      'reactor-123',
+    ]);
+
+    expect(reactAsyncStub.calledOnce).to.be.true;
+    expect(reactAsyncStub.firstCall.args[0]).to.equal('reactor-123');
+    expect(reactAsyncStub.firstCall.args[1]).to.be.undefined;
+    expect(result.stdout).to.contain('async-request-123');
+  });
+
+  it('requires reactor id argument', async () => {
+    const result = await runCommand(['reactors:invoke-async']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    reactAsyncStub.rejects(new Error('Reactor not found'));
+
+    const result = await runCommand([
+      'reactors:invoke-async',
+      'reactor-123',
+      '--data',
+      '{}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Reactor not found');
+  });
+});

--- a/test/unit/commands/reactors/invoke.test.ts
+++ b/test/unit/commands/reactors/invoke.test.ts
@@ -1,0 +1,73 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('reactors invoke', () => {
+  let reactStub: sinon.SinonStub;
+
+  const reactResponse = {
+    tokens: { token1: 'value1' },
+    raw: { key: 'raw_value' },
+  };
+
+  beforeEach(() => {
+    reactStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'reactors').get(() => ({
+      react: reactStub,
+    }));
+
+    reactStub.resolves(reactResponse);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('invokes reactor with --data flag', async () => {
+    const data = JSON.stringify({ key: 'value' });
+
+    const result = await runCommand([
+      'reactors:invoke',
+      'reactor-123',
+      '--data',
+      data,
+    ]);
+
+    expect(reactStub.calledOnce).to.be.true;
+    expect(reactStub.firstCall.args[0]).to.equal('reactor-123');
+    expect(reactStub.firstCall.args[1]).to.deep.equal({ key: 'value' });
+    expect(result.stdout).to.contain('token1');
+  });
+
+  it('invokes reactor without body', async () => {
+    const result = await runCommand(['reactors:invoke', 'reactor-123']);
+
+    expect(reactStub.calledOnce).to.be.true;
+    expect(reactStub.firstCall.args[0]).to.equal('reactor-123');
+    expect(reactStub.firstCall.args[1]).to.be.undefined;
+    expect(result.stdout).to.contain('token1');
+  });
+
+  it('requires reactor id argument', async () => {
+    const result = await runCommand(['reactors:invoke']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    reactStub.rejects(new Error('Reactor not found'));
+
+    const result = await runCommand([
+      'reactors:invoke',
+      'reactor-123',
+      '--data',
+      '{}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Reactor not found');
+  });
+});

--- a/test/unit/commands/tenants/delete.test.ts
+++ b/test/unit/commands/tenants/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('tenants delete', () => {
-  let confirmStub: sinon.SinonStub;
   let selfDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     selfDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
@@ -17,50 +14,31 @@ describe('tenants delete', () => {
     }));
 
     selfDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes tenant without confirmation prompt', async () => {
-      const result = await runCommand(['tenants:delete', '--force']);
+  it('deletes tenant', async () => {
+    const result = await runCommand(['tenants:delete']);
 
-      expect(result.stdout).to.contain('Tenant deleted successfully!');
-      expect(selfDeleteStub.calledOnce).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['tenants:delete', '-f']);
-
-      expect(result.stdout).to.contain('Tenant deleted successfully!');
-      expect(selfDeleteStub.calledOnce).to.be.true;
-    });
+    expect(result.stdout).to.contain('Tenant deleted successfully!');
+    expect(selfDeleteStub.calledOnce).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes tenant when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['tenants:delete', '--force']);
 
-      const result = await runCommand(['tenants:delete']);
+    expect(result.stdout).to.contain('Tenant deleted successfully!');
+    expect(selfDeleteStub.calledOnce).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Tenant deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(selfDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['tenants:delete', '-f']);
 
-    it('does not delete tenant when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['tenants:delete']);
-
-      expect(result.stdout).to.not.contain('Tenant deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(selfDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Tenant deleted successfully!');
+    expect(selfDeleteStub.calledOnce).to.be.true;
   });
 
   describe('error handling', () => {

--- a/test/unit/commands/tenants/delete.test.ts
+++ b/test/unit/commands/tenants/delete.test.ts
@@ -1,0 +1,76 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tenants delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let selfDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    selfDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      self: { delete: selfDeleteStub },
+    }));
+
+    selfDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes tenant without confirmation prompt', async () => {
+      const result = await runCommand(['tenants:delete', '--force']);
+
+      expect(result.stdout).to.contain('Tenant deleted successfully!');
+      expect(selfDeleteStub.calledOnce).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['tenants:delete', '-f']);
+
+      expect(result.stdout).to.contain('Tenant deleted successfully!');
+      expect(selfDeleteStub.calledOnce).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes tenant when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['tenants:delete']);
+
+      expect(result.stdout).to.contain('Tenant deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(selfDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete tenant when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['tenants:delete']);
+
+      expect(result.stdout).to.not.contain('Tenant deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(selfDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      selfDeleteStub.rejects(new Error('Delete failed'));
+
+      const result = await runCommand(['tenants:delete', '--force']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Delete failed');
+    });
+  });
+});

--- a/test/unit/commands/tenants/get.test.ts
+++ b/test/unit/commands/tenants/get.test.ts
@@ -1,0 +1,51 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantFixture } from '../../fixtures/tenants';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tenants get', () => {
+  let selfGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    selfGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      self: { get: selfGetStub },
+    }));
+
+    selfGetStub.resolves(tenantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('displays tenant details', async () => {
+    const result = await runCommand(['tenants:get']);
+
+    expect(result.stdout).to.contain('id: tenant-1');
+    expect(result.stdout).to.contain('name: Test Tenant');
+    expect(result.stdout).to.contain('type: production');
+    expect(selfGetStub.calledOnce).to.be.true;
+  });
+
+  it('outputs JSON with --json flag', async () => {
+    const result = await runCommand(['tenants:get', '--json']);
+
+    expect(result.stdout).to.contain('tenant-1');
+    expect(result.stdout).to.contain('Test Tenant');
+    expect(selfGetStub.calledOnce).to.be.true;
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      selfGetStub.rejects(new Error('Unauthorized'));
+
+      const result = await runCommand(['tenants:get']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Unauthorized');
+    });
+  });
+});

--- a/test/unit/commands/tenants/invitations/create.test.ts
+++ b/test/unit/commands/tenants/invitations/create.test.ts
@@ -1,0 +1,81 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantInvitationFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants invitations create', () => {
+  let invitationsCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    invitationsCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      invitations: { create: invitationsCreateStub },
+    }));
+
+    invitationsCreateStub.resolves(tenantInvitationFixtures[0]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with inline flags', () => {
+    it('creates invitation with email and default role', async () => {
+      const result = await runCommand([
+        'tenants:invitations:create',
+        '--email',
+        'test@example.com',
+      ]);
+
+      expect(result.stdout).to.contain('Invitation created successfully!');
+      expect(result.stdout).to.contain('id: inv-1');
+      expect(invitationsCreateStub.calledOnce).to.be.true;
+      const [createArg] = invitationsCreateStub.firstCall.args;
+
+      expect(createArg.email).to.equal('test@example.com');
+      expect(createArg.role).to.equal('ADMIN');
+    });
+
+    it('creates invitation with custom role', async () => {
+      const result = await runCommand([
+        'tenants:invitations:create',
+        '--email',
+        'test@example.com',
+        '--role',
+        'MEMBER',
+      ]);
+
+      expect(result.stdout).to.contain('Invitation created successfully!');
+      const [createArg] = invitationsCreateStub.firstCall.args;
+
+      expect(createArg.email).to.equal('test@example.com');
+      expect(createArg.role).to.equal('MEMBER');
+    });
+  });
+
+  describe('required flags', () => {
+    it('requires email flag', async () => {
+      const result = await runCommand(['tenants:invitations:create']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing required flag');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      invitationsCreateStub.rejects(new Error('Create failed'));
+
+      const result = await runCommand([
+        'tenants:invitations:create',
+        '--email',
+        'test@example.com',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Create failed');
+    });
+  });
+});

--- a/test/unit/commands/tenants/invitations/delete.test.ts
+++ b/test/unit/commands/tenants/invitations/delete.test.ts
@@ -1,0 +1,104 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants invitations delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let invitationsDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    invitationsDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      invitations: { delete: invitationsDeleteStub },
+    }));
+
+    invitationsDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes invitation without confirmation prompt', async () => {
+      const result = await runCommand([
+        'tenants:invitations:delete',
+        'inv-123',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Invitation deleted successfully!');
+      expect(invitationsDeleteStub.calledOnce).to.be.true;
+      expect(invitationsDeleteStub.calledWith('inv-123')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand([
+        'tenants:invitations:delete',
+        'inv-456',
+        '-f',
+      ]);
+
+      expect(result.stdout).to.contain('Invitation deleted successfully!');
+      expect(invitationsDeleteStub.calledWith('inv-456')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes invitation when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'tenants:invitations:delete',
+        'inv-123',
+      ]);
+
+      expect(result.stdout).to.contain('Invitation deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(invitationsDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete invitation when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'tenants:invitations:delete',
+        'inv-123',
+      ]);
+
+      expect(result.stdout).to.not.contain('Invitation deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(invitationsDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires invitation id argument', async () => {
+      const result = await runCommand(['tenants:invitations:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      invitationsDeleteStub.rejects(new Error('Invitation not found'));
+
+      const result = await runCommand([
+        'tenants:invitations:delete',
+        'inv-123',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Invitation not found');
+    });
+  });
+});

--- a/test/unit/commands/tenants/invitations/delete.test.ts
+++ b/test/unit/commands/tenants/invitations/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('tenants invitations delete', () => {
-  let confirmStub: sinon.SinonStub;
   let invitationsDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     invitationsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
@@ -17,65 +14,44 @@ describe('tenants invitations delete', () => {
     }));
 
     invitationsDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes invitation without confirmation prompt', async () => {
-      const result = await runCommand([
-        'tenants:invitations:delete',
-        'inv-123',
-        '--force',
-      ]);
+  it('deletes invitation', async () => {
+    const result = await runCommand([
+      'tenants:invitations:delete',
+      'inv-123',
+    ]);
 
-      expect(result.stdout).to.contain('Invitation deleted successfully!');
-      expect(invitationsDeleteStub.calledOnce).to.be.true;
-      expect(invitationsDeleteStub.calledWith('inv-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand([
-        'tenants:invitations:delete',
-        'inv-456',
-        '-f',
-      ]);
-
-      expect(result.stdout).to.contain('Invitation deleted successfully!');
-      expect(invitationsDeleteStub.calledWith('inv-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Invitation deleted successfully!');
+    expect(invitationsDeleteStub.calledOnce).to.be.true;
+    expect(invitationsDeleteStub.calledWith('inv-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes invitation when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'tenants:invitations:delete',
+      'inv-123',
+      '--force',
+    ]);
 
-      const result = await runCommand([
-        'tenants:invitations:delete',
-        'inv-123',
-      ]);
+    expect(result.stdout).to.contain('Invitation deleted successfully!');
+    expect(invitationsDeleteStub.calledOnce).to.be.true;
+    expect(invitationsDeleteStub.calledWith('inv-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Invitation deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(invitationsDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand([
+      'tenants:invitations:delete',
+      'inv-456',
+      '-f',
+    ]);
 
-    it('does not delete invitation when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand([
-        'tenants:invitations:delete',
-        'inv-123',
-      ]);
-
-      expect(result.stdout).to.not.contain('Invitation deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(invitationsDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Invitation deleted successfully!');
+    expect(invitationsDeleteStub.calledWith('inv-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/tenants/invitations/delete.test.ts
+++ b/test/unit/commands/tenants/invitations/delete.test.ts
@@ -21,10 +21,7 @@ describe('tenants invitations delete', () => {
   });
 
   it('deletes invitation', async () => {
-    const result = await runCommand([
-      'tenants:invitations:delete',
-      'inv-123',
-    ]);
+    const result = await runCommand(['tenants:invitations:delete', 'inv-123']);
 
     expect(result.stdout).to.contain('Invitation deleted successfully!');
     expect(invitationsDeleteStub.calledOnce).to.be.true;

--- a/test/unit/commands/tenants/invitations/index.test.ts
+++ b/test/unit/commands/tenants/invitations/index.test.ts
@@ -1,0 +1,67 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantInvitationFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants invitations', () => {
+  let invitationsListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    invitationsListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      invitations: { list: invitationsListStub },
+    }));
+
+    invitationsListStub.resolves({ data: tenantInvitationFixtures });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists tenant invitations in a table', async () => {
+    const result = await runCommand(['tenants:invitations']);
+
+    expect(result.stdout).to.contain('inv-1');
+    expect(result.stdout).to.contain('invite1@example.com');
+    expect(result.stdout).to.contain('ADMIN');
+    expect(result.stdout).to.contain('PENDING');
+    expect(invitationsListStub.calledOnce).to.be.true;
+  });
+
+  it('passes page and size flags to SDK', async () => {
+    await runCommand([
+      'tenants:invitations',
+      '--page',
+      '2',
+      '--size',
+      '10',
+    ]);
+
+    const [listArg] = invitationsListStub.firstCall.args;
+
+    expect(listArg.page).to.equal(2);
+    expect(listArg.size).to.equal(10);
+  });
+
+  it('shows message when no invitations found', async () => {
+    invitationsListStub.resolves({ data: [] });
+
+    const result = await runCommand(['tenants:invitations']);
+
+    expect(result.stdout).to.contain('No invitations found.');
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      invitationsListStub.rejects(new Error('Unauthorized'));
+
+      const result = await runCommand(['tenants:invitations']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Unauthorized');
+    });
+  });
+});

--- a/test/unit/commands/tenants/invitations/index.test.ts
+++ b/test/unit/commands/tenants/invitations/index.test.ts
@@ -32,13 +32,7 @@ describe('tenants invitations', () => {
   });
 
   it('passes page and size flags to SDK', async () => {
-    await runCommand([
-      'tenants:invitations',
-      '--page',
-      '2',
-      '--size',
-      '10',
-    ]);
+    await runCommand(['tenants:invitations', '--page', '2', '--size', '10']);
 
     const [listArg] = invitationsListStub.firstCall.args;
 

--- a/test/unit/commands/tenants/invitations/resend.test.ts
+++ b/test/unit/commands/tenants/invitations/resend.test.ts
@@ -1,0 +1,57 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantInvitationFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants invitations resend', () => {
+  let invitationsResendStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    invitationsResendStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      invitations: { resend: invitationsResendStub },
+    }));
+
+    invitationsResendStub.resolves(tenantInvitationFixtures[0]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('resends invitation', async () => {
+    const result = await runCommand([
+      'tenants:invitations:resend',
+      'inv-123',
+    ]);
+
+    expect(result.stdout).to.contain('Invitation resent successfully!');
+    expect(invitationsResendStub.calledOnce).to.be.true;
+    expect(invitationsResendStub.calledWith('inv-123')).to.be.true;
+  });
+
+  describe('required arguments', () => {
+    it('requires invitation id argument', async () => {
+      const result = await runCommand(['tenants:invitations:resend']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      invitationsResendStub.rejects(new Error('Invitation not found'));
+
+      const result = await runCommand([
+        'tenants:invitations:resend',
+        'inv-123',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Invitation not found');
+    });
+  });
+});

--- a/test/unit/commands/tenants/invitations/resend.test.ts
+++ b/test/unit/commands/tenants/invitations/resend.test.ts
@@ -22,10 +22,7 @@ describe('tenants invitations resend', () => {
   });
 
   it('resends invitation', async () => {
-    const result = await runCommand([
-      'tenants:invitations:resend',
-      'inv-123',
-    ]);
+    const result = await runCommand(['tenants:invitations:resend', 'inv-123']);
 
     expect(result.stdout).to.contain('Invitation resent successfully!');
     expect(invitationsResendStub.calledOnce).to.be.true;

--- a/test/unit/commands/tenants/members/delete.test.ts
+++ b/test/unit/commands/tenants/members/delete.test.ts
@@ -54,10 +54,7 @@ describe('tenants members delete', () => {
     it('deletes member when user confirms', async () => {
       confirmStub.resolves(true);
 
-      const result = await runCommand([
-        'tenants:members:delete',
-        'member-123',
-      ]);
+      const result = await runCommand(['tenants:members:delete', 'member-123']);
 
       expect(result.stdout).to.contain('Member deleted successfully!');
       expect(confirmStub.calledOnce).to.be.true;
@@ -67,10 +64,7 @@ describe('tenants members delete', () => {
     it('does not delete member when user declines', async () => {
       confirmStub.resolves(false);
 
-      const result = await runCommand([
-        'tenants:members:delete',
-        'member-123',
-      ]);
+      const result = await runCommand(['tenants:members:delete', 'member-123']);
 
       expect(result.stdout).to.not.contain('Member deleted successfully!');
       expect(confirmStub.calledOnce).to.be.true;

--- a/test/unit/commands/tenants/members/delete.test.ts
+++ b/test/unit/commands/tenants/members/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('tenants members delete', () => {
-  let confirmStub: sinon.SinonStub;
   let membersDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     membersDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
@@ -17,59 +14,41 @@ describe('tenants members delete', () => {
     }));
 
     membersDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes member without confirmation prompt', async () => {
-      const result = await runCommand([
-        'tenants:members:delete',
-        'member-123',
-        '--force',
-      ]);
+  it('deletes member', async () => {
+    const result = await runCommand(['tenants:members:delete', 'member-123']);
 
-      expect(result.stdout).to.contain('Member deleted successfully!');
-      expect(membersDeleteStub.calledOnce).to.be.true;
-      expect(membersDeleteStub.calledWith('member-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand([
-        'tenants:members:delete',
-        'member-456',
-        '-f',
-      ]);
-
-      expect(result.stdout).to.contain('Member deleted successfully!');
-      expect(membersDeleteStub.calledWith('member-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Member deleted successfully!');
+    expect(membersDeleteStub.calledOnce).to.be.true;
+    expect(membersDeleteStub.calledWith('member-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes member when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'tenants:members:delete',
+      'member-123',
+      '--force',
+    ]);
 
-      const result = await runCommand(['tenants:members:delete', 'member-123']);
+    expect(result.stdout).to.contain('Member deleted successfully!');
+    expect(membersDeleteStub.calledOnce).to.be.true;
+    expect(membersDeleteStub.calledWith('member-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Member deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(membersDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand([
+      'tenants:members:delete',
+      'member-456',
+      '-f',
+    ]);
 
-    it('does not delete member when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['tenants:members:delete', 'member-123']);
-
-      expect(result.stdout).to.not.contain('Member deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(membersDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Member deleted successfully!');
+    expect(membersDeleteStub.calledWith('member-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/tenants/members/delete.test.ts
+++ b/test/unit/commands/tenants/members/delete.test.ts
@@ -1,0 +1,104 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants members delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let membersDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    membersDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      members: { delete: membersDeleteStub },
+    }));
+
+    membersDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes member without confirmation prompt', async () => {
+      const result = await runCommand([
+        'tenants:members:delete',
+        'member-123',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Member deleted successfully!');
+      expect(membersDeleteStub.calledOnce).to.be.true;
+      expect(membersDeleteStub.calledWith('member-123')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand([
+        'tenants:members:delete',
+        'member-456',
+        '-f',
+      ]);
+
+      expect(result.stdout).to.contain('Member deleted successfully!');
+      expect(membersDeleteStub.calledWith('member-456')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes member when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand([
+        'tenants:members:delete',
+        'member-123',
+      ]);
+
+      expect(result.stdout).to.contain('Member deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(membersDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete member when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand([
+        'tenants:members:delete',
+        'member-123',
+      ]);
+
+      expect(result.stdout).to.not.contain('Member deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(membersDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires member id argument', async () => {
+      const result = await runCommand(['tenants:members:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      membersDeleteStub.rejects(new Error('Member not found'));
+
+      const result = await runCommand([
+        'tenants:members:delete',
+        'member-123',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Member not found');
+    });
+  });
+});

--- a/test/unit/commands/tenants/members/index.test.ts
+++ b/test/unit/commands/tenants/members/index.test.ts
@@ -31,13 +31,7 @@ describe('tenants members', () => {
   });
 
   it('passes page and size flags to SDK', async () => {
-    await runCommand([
-      'tenants:members',
-      '--page',
-      '2',
-      '--size',
-      '10',
-    ]);
+    await runCommand(['tenants:members', '--page', '2', '--size', '10']);
 
     const [listArg] = membersListStub.firstCall.args;
 
@@ -46,11 +40,7 @@ describe('tenants members', () => {
   });
 
   it('passes user-id flag to SDK', async () => {
-    await runCommand([
-      'tenants:members',
-      '--user-id',
-      'user-1',
-    ]);
+    await runCommand(['tenants:members', '--user-id', 'user-1']);
 
     const [listArg] = membersListStub.firstCall.args;
 

--- a/test/unit/commands/tenants/members/index.test.ts
+++ b/test/unit/commands/tenants/members/index.test.ts
@@ -1,0 +1,78 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantMemberFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants members', () => {
+  let membersListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    membersListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      members: { list: membersListStub },
+    }));
+
+    membersListStub.resolves({ data: tenantMemberFixtures });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists tenant members in a table', async () => {
+    const result = await runCommand(['tenants:members']);
+
+    expect(result.stdout).to.contain('member-1');
+    expect(result.stdout).to.contain('admin@example.com');
+    expect(result.stdout).to.contain('ADMIN');
+    expect(membersListStub.calledOnce).to.be.true;
+  });
+
+  it('passes page and size flags to SDK', async () => {
+    await runCommand([
+      'tenants:members',
+      '--page',
+      '2',
+      '--size',
+      '10',
+    ]);
+
+    const [listArg] = membersListStub.firstCall.args;
+
+    expect(listArg.page).to.equal(2);
+    expect(listArg.size).to.equal(10);
+  });
+
+  it('passes user-id flag to SDK', async () => {
+    await runCommand([
+      'tenants:members',
+      '--user-id',
+      'user-1',
+    ]);
+
+    const [listArg] = membersListStub.firstCall.args;
+
+    expect(listArg.userId).to.equal('user-1');
+  });
+
+  it('shows message when no members found', async () => {
+    membersListStub.resolves({ data: [] });
+
+    const result = await runCommand(['tenants:members']);
+
+    expect(result.stdout).to.contain('No members found.');
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      membersListStub.rejects(new Error('Unauthorized'));
+
+      const result = await runCommand(['tenants:members']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Unauthorized');
+    });
+  });
+});

--- a/test/unit/commands/tenants/members/update.test.ts
+++ b/test/unit/commands/tenants/members/update.test.ts
@@ -66,10 +66,7 @@ describe('tenants members update', () => {
     });
 
     it('requires role flag', async () => {
-      const result = await runCommand([
-        'tenants:members:update',
-        'member-123',
-      ]);
+      const result = await runCommand(['tenants:members:update', 'member-123']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Missing required flag');

--- a/test/unit/commands/tenants/members/update.test.ts
+++ b/test/unit/commands/tenants/members/update.test.ts
@@ -1,0 +1,94 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantMemberFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants members update', () => {
+  let membersUpdateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    membersUpdateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      members: { update: membersUpdateStub },
+    }));
+
+    membersUpdateStub.resolves(tenantMemberFixtures[0]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with inline flags', () => {
+    it('updates member role', async () => {
+      const result = await runCommand([
+        'tenants:members:update',
+        'member-123',
+        '--role',
+        'ADMIN',
+      ]);
+
+      expect(result.stdout).to.contain('Member updated successfully!');
+      expect(membersUpdateStub.calledOnce).to.be.true;
+      const [id, updateArg] = membersUpdateStub.firstCall.args;
+
+      expect(id).to.equal('member-123');
+      expect(updateArg.role).to.equal('ADMIN');
+    });
+
+    it('accepts -r shorthand flag', async () => {
+      const result = await runCommand([
+        'tenants:members:update',
+        'member-123',
+        '-r',
+        'MEMBER',
+      ]);
+
+      expect(result.stdout).to.contain('Member updated successfully!');
+      const [, updateArg] = membersUpdateStub.firstCall.args;
+
+      expect(updateArg.role).to.equal('MEMBER');
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires member id argument', async () => {
+      const result = await runCommand([
+        'tenants:members:update',
+        '--role',
+        'ADMIN',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+
+    it('requires role flag', async () => {
+      const result = await runCommand([
+        'tenants:members:update',
+        'member-123',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing required flag');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      membersUpdateStub.rejects(new Error('Update failed'));
+
+      const result = await runCommand([
+        'tenants:members:update',
+        'member-123',
+        '--role',
+        'ADMIN',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Update failed');
+    });
+  });
+});

--- a/test/unit/commands/tenants/merchants/index.test.ts
+++ b/test/unit/commands/tenants/merchants/index.test.ts
@@ -1,7 +1,10 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { tenantFixture, tenantMerchantFixtures } from '../../../fixtures/tenants';
+import {
+  tenantFixture,
+  tenantMerchantFixtures,
+} from '../../../fixtures/tenants';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('tenants merchants', () => {

--- a/test/unit/commands/tenants/merchants/index.test.ts
+++ b/test/unit/commands/tenants/merchants/index.test.ts
@@ -9,10 +9,12 @@ describe('tenants merchants', () => {
   beforeEach(() => {
     fetchStub = sinon.stub(global, 'fetch');
 
-    fetchStub.resolves(new Response(
-      JSON.stringify({ data: tenantMerchantFixtures }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    ));
+    fetchStub.resolves(
+      new Response(JSON.stringify({ data: tenantMerchantFixtures }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
   });
 
   afterEach(() => {
@@ -49,10 +51,12 @@ describe('tenants merchants', () => {
   });
 
   it('shows message when no merchants found', async () => {
-    fetchStub.resolves(new Response(
-      JSON.stringify({ data: [] }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    ));
+    fetchStub.resolves(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
 
     const result = await runCommand([
       'tenants:merchants',
@@ -65,10 +69,7 @@ describe('tenants merchants', () => {
 
   describe('error handling', () => {
     it('handles API errors', async () => {
-      fetchStub.resolves(new Response(
-        'Unauthorized',
-        { status: 401 }
-      ));
+      fetchStub.resolves(new Response('Unauthorized', { status: 401 }));
 
       const result = await runCommand([
         'tenants:merchants',

--- a/test/unit/commands/tenants/merchants/index.test.ts
+++ b/test/unit/commands/tenants/merchants/index.test.ts
@@ -1,13 +1,22 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { tenantMerchantFixtures } from '../../../fixtures/tenants';
+import { tenantFixture, tenantMerchantFixtures } from '../../../fixtures/tenants';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('tenants merchants', () => {
   let fetchStub: sinon.SinonStub;
+  let tenantSelfGetStub: sinon.SinonStub;
 
   beforeEach(() => {
     fetchStub = sinon.stub(global, 'fetch');
+    tenantSelfGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      self: { get: tenantSelfGetStub },
+    }));
+
+    tenantSelfGetStub.resolves(tenantFixture);
 
     fetchStub.resolves(
       new Response(JSON.stringify({ data: tenantMerchantFixtures }), {

--- a/test/unit/commands/tenants/merchants/index.test.ts
+++ b/test/unit/commands/tenants/merchants/index.test.ts
@@ -1,20 +1,18 @@
-import { BasisTheoryClient } from '@basis-theory/node-sdk';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { tenantMerchantFixtures } from '../../../fixtures/tenants';
 import { runCommand } from '../../../helpers/run-command';
 
 describe('tenants merchants', () => {
-  let merchantsListStub: sinon.SinonStub;
+  let fetchStub: sinon.SinonStub;
 
   beforeEach(() => {
-    merchantsListStub = sinon.stub();
+    fetchStub = sinon.stub(global, 'fetch');
 
-    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
-      merchants: { list: merchantsListStub },
-    }));
-
-    merchantsListStub.resolves({ data: tenantMerchantFixtures });
+    fetchStub.resolves(new Response(
+      JSON.stringify({ data: tenantMerchantFixtures }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    ));
   });
 
   afterEach(() => {
@@ -22,44 +20,64 @@ describe('tenants merchants', () => {
   });
 
   it('lists tenant merchants in a table', async () => {
-    const result = await runCommand(['tenants:merchants']);
+    const result = await runCommand([
+      'tenants:merchants',
+      '--management-key',
+      'test_key',
+    ]);
 
     expect(result.stdout).to.contain('merchant-1');
     expect(result.stdout).to.contain('Test Merchant 1');
-    expect(merchantsListStub.calledOnce).to.be.true;
+    expect(fetchStub.calledOnce).to.be.true;
   });
 
-  it('passes page and size flags to SDK', async () => {
+  it('passes page and size flags to URL', async () => {
     await runCommand([
       'tenants:merchants',
+      '--management-key',
+      'test_key',
       '--page',
       '2',
       '--size',
       '10',
     ]);
 
-    const [listArg] = merchantsListStub.firstCall.args;
+    const [url] = fetchStub.firstCall.args;
 
-    expect(listArg.page).to.equal(2);
-    expect(listArg.size).to.equal(10);
+    expect(url).to.contain('page=2');
+    expect(url).to.contain('size=10');
   });
 
   it('shows message when no merchants found', async () => {
-    merchantsListStub.resolves({ data: [] });
+    fetchStub.resolves(new Response(
+      JSON.stringify({ data: [] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    ));
 
-    const result = await runCommand(['tenants:merchants']);
+    const result = await runCommand([
+      'tenants:merchants',
+      '--management-key',
+      'test_key',
+    ]);
 
     expect(result.stdout).to.contain('No merchants found.');
   });
 
   describe('error handling', () => {
     it('handles API errors', async () => {
-      merchantsListStub.rejects(new Error('Unauthorized'));
+      fetchStub.resolves(new Response(
+        'Unauthorized',
+        { status: 401 }
+      ));
 
-      const result = await runCommand(['tenants:merchants']);
+      const result = await runCommand([
+        'tenants:merchants',
+        '--management-key',
+        'test_key',
+      ]);
 
       expect(result.error).to.exist;
-      expect(result.error!.message).to.contain('Unauthorized');
+      expect(result.error!.message).to.contain('401');
     });
   });
 });

--- a/test/unit/commands/tenants/merchants/index.test.ts
+++ b/test/unit/commands/tenants/merchants/index.test.ts
@@ -1,0 +1,65 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantMerchantFixtures } from '../../../fixtures/tenants';
+import { runCommand } from '../../../helpers/run-command';
+
+describe('tenants merchants', () => {
+  let merchantsListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    merchantsListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      merchants: { list: merchantsListStub },
+    }));
+
+    merchantsListStub.resolves({ data: tenantMerchantFixtures });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists tenant merchants in a table', async () => {
+    const result = await runCommand(['tenants:merchants']);
+
+    expect(result.stdout).to.contain('merchant-1');
+    expect(result.stdout).to.contain('Test Merchant 1');
+    expect(merchantsListStub.calledOnce).to.be.true;
+  });
+
+  it('passes page and size flags to SDK', async () => {
+    await runCommand([
+      'tenants:merchants',
+      '--page',
+      '2',
+      '--size',
+      '10',
+    ]);
+
+    const [listArg] = merchantsListStub.firstCall.args;
+
+    expect(listArg.page).to.equal(2);
+    expect(listArg.size).to.equal(10);
+  });
+
+  it('shows message when no merchants found', async () => {
+    merchantsListStub.resolves({ data: [] });
+
+    const result = await runCommand(['tenants:merchants']);
+
+    expect(result.stdout).to.contain('No merchants found.');
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      merchantsListStub.rejects(new Error('Unauthorized'));
+
+      const result = await runCommand(['tenants:merchants']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Unauthorized');
+    });
+  });
+});

--- a/test/unit/commands/tenants/update.test.ts
+++ b/test/unit/commands/tenants/update.test.ts
@@ -73,11 +73,7 @@ describe('tenants update', () => {
     it('handles API errors', async () => {
       selfUpdateStub.rejects(new Error('Update failed'));
 
-      const result = await runCommand([
-        'tenants:update',
-        '--name',
-        'Updated',
-      ]);
+      const result = await runCommand(['tenants:update', '--name', 'Updated']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Update failed');

--- a/test/unit/commands/tenants/update.test.ts
+++ b/test/unit/commands/tenants/update.test.ts
@@ -1,0 +1,86 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantFixture } from '../../fixtures/tenants';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tenants update', () => {
+  let selfUpdateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    selfUpdateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      self: { update: selfUpdateStub },
+    }));
+
+    selfUpdateStub.resolves(tenantFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with inline flags', () => {
+    it('updates tenant name', async () => {
+      const result = await runCommand([
+        'tenants:update',
+        '--name',
+        'Updated Tenant',
+      ]);
+
+      expect(result.stdout).to.contain('Tenant updated successfully!');
+      expect(selfUpdateStub.calledOnce).to.be.true;
+      const [updateArg] = selfUpdateStub.firstCall.args;
+
+      expect(updateArg.name).to.equal('Updated Tenant');
+    });
+
+    it('updates tenant settings', async () => {
+      const result = await runCommand([
+        'tenants:update',
+        '--fingerprint-tokens',
+        'enabled',
+        '--deduplicate-tokens',
+        'disabled',
+      ]);
+
+      expect(result.stdout).to.contain('Tenant updated successfully!');
+      const [updateArg] = selfUpdateStub.firstCall.args;
+
+      expect(updateArg.settings.fingerprintTokens).to.equal('enabled');
+      expect(updateArg.settings.deduplicateTokens).to.equal('disabled');
+    });
+
+    it('updates name and settings together', async () => {
+      const result = await runCommand([
+        'tenants:update',
+        '--name',
+        'New Name',
+        '--disable-ephemeral-proxy',
+        'enabled',
+      ]);
+
+      expect(result.stdout).to.contain('Tenant updated successfully!');
+      const [updateArg] = selfUpdateStub.firstCall.args;
+
+      expect(updateArg.name).to.equal('New Name');
+      expect(updateArg.settings.disableEphemeralProxy).to.equal('enabled');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      selfUpdateStub.rejects(new Error('Update failed'));
+
+      const result = await runCommand([
+        'tenants:update',
+        '--name',
+        'Updated',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Update failed');
+    });
+  });
+});

--- a/test/unit/commands/tenants/usage.test.ts
+++ b/test/unit/commands/tenants/usage.test.ts
@@ -1,0 +1,41 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tenantUsageReportFixture } from '../../fixtures/tenants';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tenants usage', () => {
+  let getUsageReportsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getUsageReportsStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tenants').get(() => ({
+      self: { getUsageReports: getUsageReportsStub },
+    }));
+
+    getUsageReportsStub.resolves(tenantUsageReportFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('displays usage report', async () => {
+    const result = await runCommand(['tenants:usage']);
+
+    expect(result.stdout).to.contain('tokenReport');
+    expect(getUsageReportsStub.calledOnce).to.be.true;
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      getUsageReportsStub.rejects(new Error('Unauthorized'));
+
+      const result = await runCommand(['tenants:usage']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Unauthorized');
+    });
+  });
+});

--- a/test/unit/commands/token-intents/create.test.ts
+++ b/test/unit/commands/token-intents/create.test.ts
@@ -37,7 +37,9 @@ describe('token-intents create', () => {
     expect(createArg.type).to.equal('card');
     expect(createArg.data).to.deep.equal({
       number: '4242424242424242',
+      // eslint-disable-next-line camelcase
       expiration_month: 12,
+      // eslint-disable-next-line camelcase
       expiration_year: 2025,
     });
   });
@@ -54,11 +56,7 @@ describe('token-intents create', () => {
   });
 
   it('requires --data or --file flag', async () => {
-    const result = await runCommand([
-      'token-intents:create',
-      '--type',
-      'card',
-    ]);
+    const result = await runCommand(['token-intents:create', '--type', 'card']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain(

--- a/test/unit/commands/token-intents/create.test.ts
+++ b/test/unit/commands/token-intents/create.test.ts
@@ -1,0 +1,83 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { createTokenIntentResponse } from '../../fixtures/token-intents';
+import { runCommand } from '../../helpers/run-command';
+
+describe('token-intents create', () => {
+  let tokenIntentsCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokenIntentsCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokenIntents').get(() => ({
+      create: tokenIntentsCreateStub,
+    }));
+
+    tokenIntentsCreateStub.resolves(createTokenIntentResponse);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a token intent with type and data', async () => {
+    const result = await runCommand([
+      'token-intents:create',
+      '--type',
+      'card',
+      '--data',
+      '{"number":"4242424242424242","expiration_month":12,"expiration_year":2025}',
+    ]);
+
+    expect(result.stdout).to.contain('ti-1');
+    expect(tokenIntentsCreateStub.calledOnce).to.be.true;
+    const [createArg] = tokenIntentsCreateStub.firstCall.args;
+
+    expect(createArg.type).to.equal('card');
+    expect(createArg.data).to.deep.equal({
+      number: '4242424242424242',
+      expiration_month: 12,
+      expiration_year: 2025,
+    });
+  });
+
+  it('requires type flag', async () => {
+    const result = await runCommand([
+      'token-intents:create',
+      '--data',
+      '{"number":"4242"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('requires --data or --file flag', async () => {
+    const result = await runCommand([
+      'token-intents:create',
+      '--type',
+      'card',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided.'
+    );
+  });
+
+  it('handles API errors', async () => {
+    tokenIntentsCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'token-intents:create',
+      '--type',
+      'card',
+      '--data',
+      '{"number":"4242"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/token-intents/delete.test.ts
+++ b/test/unit/commands/token-intents/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('token-intents delete', () => {
-  let confirmStub: sinon.SinonStub;
   let tokenIntentsDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     tokenIntentsDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'tokenIntents').get(() => ({
@@ -17,57 +14,37 @@ describe('token-intents delete', () => {
     }));
 
     tokenIntentsDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes token intent without confirmation prompt', async () => {
-      const result = await runCommand([
-        'token-intents:delete',
-        'ti-123',
-        '--force',
-      ]);
+  it('deletes token intent', async () => {
+    const result = await runCommand(['token-intents:delete', 'ti-123']);
 
-      expect(result.stdout).to.contain('Token intent deleted successfully!');
-      expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
-      expect(tokenIntentsDeleteStub.calledWith('ti-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['token-intents:delete', 'ti-456', '-f']);
-
-      expect(result.stdout).to.contain('Token intent deleted successfully!');
-      expect(tokenIntentsDeleteStub.calledWith('ti-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Token intent deleted successfully!');
+    expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
+    expect(tokenIntentsDeleteStub.calledWith('ti-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes token intent when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand([
+      'token-intents:delete',
+      'ti-123',
+      '--force',
+    ]);
 
-      const result = await runCommand(['token-intents:delete', 'ti-123']);
+    expect(result.stdout).to.contain('Token intent deleted successfully!');
+    expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
+    expect(tokenIntentsDeleteStub.calledWith('ti-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Token intent deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['token-intents:delete', 'ti-456', '-f']);
 
-    it('does not delete token intent when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['token-intents:delete', 'ti-123']);
-
-      expect(result.stdout).to.not.contain(
-        'Token intent deleted successfully!'
-      );
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(tokenIntentsDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Token intent deleted successfully!');
+    expect(tokenIntentsDeleteStub.calledWith('ti-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/token-intents/delete.test.ts
+++ b/test/unit/commands/token-intents/delete.test.ts
@@ -39,11 +39,7 @@ describe('token-intents delete', () => {
     });
 
     it('accepts -f shorthand flag', async () => {
-      const result = await runCommand([
-        'token-intents:delete',
-        'ti-456',
-        '-f',
-      ]);
+      const result = await runCommand(['token-intents:delete', 'ti-456', '-f']);
 
       expect(result.stdout).to.contain('Token intent deleted successfully!');
       expect(tokenIntentsDeleteStub.calledWith('ti-456')).to.be.true;

--- a/test/unit/commands/token-intents/delete.test.ts
+++ b/test/unit/commands/token-intents/delete.test.ts
@@ -1,0 +1,100 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('token-intents delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let tokenIntentsDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    tokenIntentsDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokenIntents').get(() => ({
+      delete: tokenIntentsDeleteStub,
+    }));
+
+    tokenIntentsDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes token intent without confirmation prompt', async () => {
+      const result = await runCommand([
+        'token-intents:delete',
+        'ti-123',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Token intent deleted successfully!');
+      expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
+      expect(tokenIntentsDeleteStub.calledWith('ti-123')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand([
+        'token-intents:delete',
+        'ti-456',
+        '-f',
+      ]);
+
+      expect(result.stdout).to.contain('Token intent deleted successfully!');
+      expect(tokenIntentsDeleteStub.calledWith('ti-456')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes token intent when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['token-intents:delete', 'ti-123']);
+
+      expect(result.stdout).to.contain('Token intent deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(tokenIntentsDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete token intent when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['token-intents:delete', 'ti-123']);
+
+      expect(result.stdout).to.not.contain(
+        'Token intent deleted successfully!'
+      );
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(tokenIntentsDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires token intent id argument', async () => {
+      const result = await runCommand(['token-intents:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      tokenIntentsDeleteStub.rejects(new Error('Token intent not found'));
+
+      const result = await runCommand([
+        'token-intents:delete',
+        'ti-123',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Token intent not found');
+    });
+  });
+});

--- a/test/unit/commands/token-intents/get.test.ts
+++ b/test/unit/commands/token-intents/get.test.ts
@@ -1,0 +1,46 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenIntentFixtures } from '../../fixtures/token-intents';
+import { runCommand } from '../../helpers/run-command';
+
+describe('token-intents get', () => {
+  let tokenIntentsGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokenIntentsGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokenIntents').get(() => ({
+      get: tokenIntentsGetStub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retrieves and displays a token intent', async () => {
+    tokenIntentsGetStub.resolves(tokenIntentFixtures.card1);
+
+    const result = await runCommand(['token-intents:get', 'ti-1']);
+
+    expect(result.stdout).to.contain('ti-1');
+    expect(tokenIntentsGetStub.calledWith('ti-1')).to.be.true;
+  });
+
+  it('requires token intent id argument', async () => {
+    const result = await runCommand(['token-intents:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    tokenIntentsGetStub.rejects(new Error('Token intent not found'));
+
+    const result = await runCommand(['token-intents:get', 'ti-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Token intent not found');
+  });
+});

--- a/test/unit/commands/tokenize.test.ts
+++ b/test/unit/commands/tokenize.test.ts
@@ -19,7 +19,10 @@ describe('tokenize', () => {
   });
 
   it('tokenizes data with --data flag', async () => {
-    const tokenizeResult = { id: 'tok-1', type: 'token' };
+    const tokenizeResult = {
+      id: 'tok-1',
+      type: 'token',
+    };
 
     tokensTokenizeStub.resolves(tokenizeResult);
 
@@ -33,7 +36,10 @@ describe('tokenize', () => {
     expect(tokensTokenizeStub.calledOnce).to.be.true;
     const [input] = tokensTokenizeStub.firstCall.args;
 
-    expect(input).to.deep.equal({ type: 'token', data: 'secret' });
+    expect(input).to.deep.equal({
+      type: 'token',
+      data: 'secret',
+    });
   });
 
   it('requires --data or --file flag', async () => {

--- a/test/unit/commands/tokenize.test.ts
+++ b/test/unit/commands/tokenize.test.ts
@@ -1,0 +1,67 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../helpers/run-command';
+
+describe('tokenize', () => {
+  let tokensTokenizeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensTokenizeStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      tokenize: tokensTokenizeStub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('tokenizes data with --data flag', async () => {
+    const tokenizeResult = { id: 'tok-1', type: 'token' };
+
+    tokensTokenizeStub.resolves(tokenizeResult);
+
+    const result = await runCommand([
+      'tokenize',
+      '--data',
+      '{"type":"token","data":"secret"}',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(tokensTokenizeStub.calledOnce).to.be.true;
+    const [input] = tokensTokenizeStub.firstCall.args;
+
+    expect(input).to.deep.equal({ type: 'token', data: 'secret' });
+  });
+
+  it('requires --data or --file flag', async () => {
+    const result = await runCommand(['tokenize']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain(
+      'Either --data or --file must be provided.'
+    );
+  });
+
+  it('handles invalid JSON in --data flag', async () => {
+    const result = await runCommand(['tokenize', '--data', 'not-json']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Invalid JSON');
+  });
+
+  it('handles API errors', async () => {
+    tokensTokenizeStub.rejects(new Error('Tokenize failed'));
+
+    const result = await runCommand([
+      'tokenize',
+      '--data',
+      '{"type":"token","data":"secret"}',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Tokenize failed');
+  });
+});

--- a/test/unit/commands/tokens/create.test.ts
+++ b/test/unit/commands/tokens/create.test.ts
@@ -1,0 +1,158 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenFixtures } from '../../fixtures/tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens create', () => {
+  let tokensCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      create: tokensCreateStub,
+    }));
+
+    tokensCreateStub.resolves(tokenFixtures.token1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a token with type and data flags', async () => {
+    const result = await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"secret-value"',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(tokensCreateStub.calledOnce).to.be.true;
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.type).to.equal('token');
+    expect(createArg.data).to.equal('secret-value');
+  });
+
+  it('creates a token with JSON object data', async () => {
+    const result = await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '{"key":"value"}',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.data).to.deep.equal({ key: 'value' });
+  });
+
+  it('creates a token with token-intent-id', async () => {
+    await runCommand([
+      'tokens:create',
+      '--token-intent-id',
+      'ti-123',
+    ]);
+
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.tokenIntentId).to.equal('ti-123');
+  });
+
+  it('creates a token with containers', async () => {
+    await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"test"',
+      '--container',
+      '/general/high/',
+      '--container',
+      '/pci/high/',
+    ]);
+
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.containers).to.deep.equal([
+      '/general/high/',
+      '/pci/high/',
+    ]);
+  });
+
+  it('creates a token with metadata', async () => {
+    await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"test"',
+      '--metadata',
+      'env=prod',
+      '--metadata',
+      'team=backend',
+    ]);
+
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.metadata).to.deep.equal({
+      env: 'prod',
+      team: 'backend',
+    });
+  });
+
+  it('creates a token with expires-at', async () => {
+    await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"test"',
+      '--expires-at',
+      '2025-12-31T00:00:00Z',
+    ]);
+
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.expiresAt).to.equal('2025-12-31T00:00:00Z');
+  });
+
+  it('creates a token with fingerprint-expression and deduplicate', async () => {
+    await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"test"',
+      '--fingerprint-expression',
+      '{{ data }}',
+      '--deduplicate',
+    ]);
+
+    const [createArg] = tokensCreateStub.firstCall.args;
+
+    expect(createArg.fingerprintExpression).to.equal('{{ data }}');
+    expect(createArg.deduplicateToken).to.be.true;
+  });
+
+  it('handles API errors', async () => {
+    tokensCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'tokens:create',
+      '--type',
+      'token',
+      '--data',
+      '"test"',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/tokens/create.test.ts
+++ b/test/unit/commands/tokens/create.test.ts
@@ -54,11 +54,7 @@ describe('tokens create', () => {
   });
 
   it('creates a token with token-intent-id', async () => {
-    await runCommand([
-      'tokens:create',
-      '--token-intent-id',
-      'ti-123',
-    ]);
+    await runCommand(['tokens:create', '--token-intent-id', 'ti-123']);
 
     const [createArg] = tokensCreateStub.firstCall.args;
 

--- a/test/unit/commands/tokens/delete.test.ts
+++ b/test/unit/commands/tokens/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('tokens delete', () => {
-  let confirmStub: sinon.SinonStub;
   let tokensDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     tokensDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
@@ -17,51 +14,33 @@ describe('tokens delete', () => {
     }));
 
     tokensDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes token without confirmation prompt', async () => {
-      const result = await runCommand(['tokens:delete', 'tok-123', '--force']);
+  it('deletes token', async () => {
+    const result = await runCommand(['tokens:delete', 'tok-123']);
 
-      expect(result.stdout).to.contain('Token deleted successfully!');
-      expect(tokensDeleteStub.calledOnce).to.be.true;
-      expect(tokensDeleteStub.calledWith('tok-123')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['tokens:delete', 'tok-456', '-f']);
-
-      expect(result.stdout).to.contain('Token deleted successfully!');
-      expect(tokensDeleteStub.calledWith('tok-456')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Token deleted successfully!');
+    expect(tokensDeleteStub.calledOnce).to.be.true;
+    expect(tokensDeleteStub.calledWith('tok-123')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes token when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['tokens:delete', 'tok-123', '--force']);
 
-      const result = await runCommand(['tokens:delete', 'tok-123']);
+    expect(result.stdout).to.contain('Token deleted successfully!');
+    expect(tokensDeleteStub.calledOnce).to.be.true;
+    expect(tokensDeleteStub.calledWith('tok-123')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Token deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(tokensDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['tokens:delete', 'tok-456', '-f']);
 
-    it('does not delete token when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['tokens:delete', 'tok-123']);
-
-      expect(result.stdout).to.not.contain('Token deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(tokensDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Token deleted successfully!');
+    expect(tokensDeleteStub.calledWith('tok-456')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/tokens/delete.test.ts
+++ b/test/unit/commands/tokens/delete.test.ts
@@ -1,0 +1,94 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let tokensDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    tokensDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      delete: tokensDeleteStub,
+    }));
+
+    tokensDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes token without confirmation prompt', async () => {
+      const result = await runCommand([
+        'tokens:delete',
+        'tok-123',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Token deleted successfully!');
+      expect(tokensDeleteStub.calledOnce).to.be.true;
+      expect(tokensDeleteStub.calledWith('tok-123')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['tokens:delete', 'tok-456', '-f']);
+
+      expect(result.stdout).to.contain('Token deleted successfully!');
+      expect(tokensDeleteStub.calledWith('tok-456')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes token when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['tokens:delete', 'tok-123']);
+
+      expect(result.stdout).to.contain('Token deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(tokensDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete token when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['tokens:delete', 'tok-123']);
+
+      expect(result.stdout).to.not.contain('Token deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(tokensDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires token id argument', async () => {
+      const result = await runCommand(['tokens:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      tokensDeleteStub.rejects(new Error('Token not found'));
+
+      const result = await runCommand([
+        'tokens:delete',
+        'tok-123',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Token not found');
+    });
+  });
+});

--- a/test/unit/commands/tokens/delete.test.ts
+++ b/test/unit/commands/tokens/delete.test.ts
@@ -26,11 +26,7 @@ describe('tokens delete', () => {
 
   describe('with --force flag', () => {
     it('deletes token without confirmation prompt', async () => {
-      const result = await runCommand([
-        'tokens:delete',
-        'tok-123',
-        '--force',
-      ]);
+      const result = await runCommand(['tokens:delete', 'tok-123', '--force']);
 
       expect(result.stdout).to.contain('Token deleted successfully!');
       expect(tokensDeleteStub.calledOnce).to.be.true;
@@ -81,11 +77,7 @@ describe('tokens delete', () => {
     it('handles API errors', async () => {
       tokensDeleteStub.rejects(new Error('Token not found'));
 
-      const result = await runCommand([
-        'tokens:delete',
-        'tok-123',
-        '--force',
-      ]);
+      const result = await runCommand(['tokens:delete', 'tok-123', '--force']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Token not found');

--- a/test/unit/commands/tokens/get.test.ts
+++ b/test/unit/commands/tokens/get.test.ts
@@ -1,0 +1,46 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenFixtures } from '../../fixtures/tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens get', () => {
+  let tokensGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      get: tokensGetStub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retrieves and displays a token', async () => {
+    tokensGetStub.resolves(tokenFixtures.token1);
+
+    const result = await runCommand(['tokens:get', 'tok-1']);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(tokensGetStub.calledWith('tok-1')).to.be.true;
+  });
+
+  it('requires token id argument', async () => {
+    const result = await runCommand(['tokens:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    tokensGetStub.rejects(new Error('Token not found'));
+
+    const result = await runCommand(['tokens:get', 'tok-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Token not found');
+  });
+});

--- a/test/unit/commands/tokens/index.test.ts
+++ b/test/unit/commands/tokens/index.test.ts
@@ -1,0 +1,87 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenFixtures } from '../../fixtures/tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens list', () => {
+  let tokensListV2Stub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensListV2Stub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      listV2: tokensListV2Stub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('displays tokens in a table', async () => {
+    tokensListV2Stub.resolves({
+      data: [tokenFixtures.token1, tokenFixtures.card1],
+    });
+
+    const result = await runCommand(['tokens']);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(result.stdout).to.contain('token');
+    expect(result.stdout).to.contain('tok-2');
+    expect(result.stdout).to.contain('card');
+    expect(tokensListV2Stub.calledOnce).to.be.true;
+  });
+
+  it('displays message when no tokens found', async () => {
+    tokensListV2Stub.resolves({ data: [] });
+
+    const result = await runCommand(['tokens']);
+
+    expect(result.stdout).to.contain('No tokens found.');
+  });
+
+  it('passes filter flags to API', async () => {
+    tokensListV2Stub.resolves({ data: [] });
+
+    await runCommand([
+      'tokens',
+      '--container',
+      '/general/high/',
+      '--type',
+      'token',
+      '--fingerprint',
+      'fp-123',
+      '--size',
+      '10',
+    ]);
+
+    expect(
+      tokensListV2Stub.calledWith({
+        container: '/general/high/',
+        type: 'token',
+        fingerprint: 'fp-123',
+        size: 10,
+      })
+    ).to.be.true;
+  });
+
+  it('uses default size of 20', async () => {
+    tokensListV2Stub.resolves({ data: [] });
+
+    await runCommand(['tokens']);
+
+    const callArgs = tokensListV2Stub.firstCall.args[0];
+
+    expect(callArgs.size).to.equal(20);
+  });
+
+  it('handles API errors', async () => {
+    tokensListV2Stub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['tokens']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/tokens/search.test.ts
+++ b/test/unit/commands/tokens/search.test.ts
@@ -1,0 +1,98 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenFixtures } from '../../fixtures/tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens search', () => {
+  let tokensSearchV2Stub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensSearchV2Stub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      searchV2: tokensSearchV2Stub,
+    }));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('searches tokens and displays results', async () => {
+    tokensSearchV2Stub.resolves({
+      data: [tokenFixtures.token1, tokenFixtures.card1],
+    });
+
+    const result = await runCommand([
+      'tokens:search',
+      '--query',
+      'data:secret',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(result.stdout).to.contain('tok-2');
+    expect(tokensSearchV2Stub.calledOnce).to.be.true;
+  });
+
+  it('passes query and size to API', async () => {
+    tokensSearchV2Stub.resolves({ data: [] });
+
+    await runCommand([
+      'tokens:search',
+      '--query',
+      'data:4242',
+      '--size',
+      '10',
+    ]);
+
+    expect(
+      tokensSearchV2Stub.calledWith({
+        query: 'data:4242',
+        size: 10,
+      })
+    ).to.be.true;
+  });
+
+  it('uses default size of 20', async () => {
+    tokensSearchV2Stub.resolves({ data: [] });
+
+    await runCommand(['tokens:search', '--query', 'data:test']);
+
+    const callArgs = tokensSearchV2Stub.firstCall.args[0];
+
+    expect(callArgs.size).to.equal(20);
+  });
+
+  it('displays message when no tokens found', async () => {
+    tokensSearchV2Stub.resolves({ data: [] });
+
+    const result = await runCommand([
+      'tokens:search',
+      '--query',
+      'data:nonexistent',
+    ]);
+
+    expect(result.stdout).to.contain('No tokens found.');
+  });
+
+  it('requires query flag', async () => {
+    const result = await runCommand(['tokens:search']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    tokensSearchV2Stub.rejects(new Error('Search failed'));
+
+    const result = await runCommand([
+      'tokens:search',
+      '--query',
+      'data:test',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Search failed');
+  });
+});

--- a/test/unit/commands/tokens/search.test.ts
+++ b/test/unit/commands/tokens/search.test.ts
@@ -38,13 +38,7 @@ describe('tokens search', () => {
   it('passes query and size to API', async () => {
     tokensSearchV2Stub.resolves({ data: [] });
 
-    await runCommand([
-      'tokens:search',
-      '--query',
-      'data:4242',
-      '--size',
-      '10',
-    ]);
+    await runCommand(['tokens:search', '--query', 'data:4242', '--size', '10']);
 
     expect(
       tokensSearchV2Stub.calledWith({
@@ -86,11 +80,7 @@ describe('tokens search', () => {
   it('handles API errors', async () => {
     tokensSearchV2Stub.rejects(new Error('Search failed'));
 
-    const result = await runCommand([
-      'tokens:search',
-      '--query',
-      'data:test',
-    ]);
+    const result = await runCommand(['tokens:search', '--query', 'data:test']);
 
     expect(result.error).to.exist;
     expect(result.error!.message).to.contain('Search failed');

--- a/test/unit/commands/tokens/types.test.ts
+++ b/test/unit/commands/tokens/types.test.ts
@@ -1,0 +1,33 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens types', () => {
+  beforeEach(() => {
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({}));
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('displays token types in a table', async () => {
+    const result = await runCommand(['tokens:types']);
+
+    expect(result.stdout).to.contain('token');
+    expect(result.stdout).to.contain('card');
+    expect(result.stdout).to.contain('card_number');
+    expect(result.stdout).to.contain('bank');
+    expect(result.stdout).to.contain('network_token');
+    expect(result.stdout).to.contain('social_security_number');
+    expect(result.stdout).to.contain('employer_id_number');
+    expect(result.stdout).to.contain('us_bank_account_number');
+    expect(result.stdout).to.contain('us_bank_routing_number');
+    expect(result.stdout).to.contain('/general/high/');
+    expect(result.stdout).to.contain('/pci/high/');
+    expect(result.stdout).to.contain('/bank/high/');
+    expect(result.stdout).to.contain('/bank/low/');
+    expect(result.stdout).to.contain('/pii/high/');
+  });
+});

--- a/test/unit/commands/tokens/update.test.ts
+++ b/test/unit/commands/tokens/update.test.ts
@@ -1,0 +1,99 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { tokenFixtures } from '../../fixtures/tokens';
+import { runCommand } from '../../helpers/run-command';
+
+describe('tokens update', () => {
+  let tokensUpdateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    tokensUpdateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'tokens').get(() => ({
+      update: tokensUpdateStub,
+    }));
+
+    tokensUpdateStub.resolves(tokenFixtures.token1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('updates a token with data', async () => {
+    const result = await runCommand([
+      'tokens:update',
+      'tok-1',
+      '--data',
+      '"new-value"',
+    ]);
+
+    expect(result.stdout).to.contain('tok-1');
+    expect(tokensUpdateStub.calledOnce).to.be.true;
+    const [id, updateArg] = tokensUpdateStub.firstCall.args;
+
+    expect(id).to.equal('tok-1');
+    expect(updateArg.data).to.equal('new-value');
+  });
+
+  it('updates a token with containers', async () => {
+    await runCommand([
+      'tokens:update',
+      'tok-1',
+      '--container',
+      '/general/high/',
+    ]);
+
+    const [, updateArg] = tokensUpdateStub.firstCall.args;
+
+    expect(updateArg.containers).to.deep.equal(['/general/high/']);
+  });
+
+  it('updates a token with metadata', async () => {
+    await runCommand([
+      'tokens:update',
+      'tok-1',
+      '--metadata',
+      'env=staging',
+    ]);
+
+    const [, updateArg] = tokensUpdateStub.firstCall.args;
+
+    expect(updateArg.metadata).to.deep.equal({ env: 'staging' });
+  });
+
+  it('updates a token with expires-at', async () => {
+    await runCommand([
+      'tokens:update',
+      'tok-1',
+      '--expires-at',
+      '2025-12-31T00:00:00Z',
+    ]);
+
+    const [, updateArg] = tokensUpdateStub.firstCall.args;
+
+    expect(updateArg.expiresAt).to.equal('2025-12-31T00:00:00Z');
+  });
+
+  it('requires token id argument', async () => {
+    const result = await runCommand(['tokens:update']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    tokensUpdateStub.rejects(new Error('Token not found'));
+
+    const result = await runCommand([
+      'tokens:update',
+      'tok-invalid',
+      '--data',
+      '"test"',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Token not found');
+  });
+});

--- a/test/unit/commands/tokens/update.test.ts
+++ b/test/unit/commands/tokens/update.test.ts
@@ -51,12 +51,7 @@ describe('tokens update', () => {
   });
 
   it('updates a token with metadata', async () => {
-    await runCommand([
-      'tokens:update',
-      'tok-1',
-      '--metadata',
-      'env=staging',
-    ]);
+    await runCommand(['tokens:update', 'tok-1', '--metadata', 'env=staging']);
 
     const [, updateArg] = tokensUpdateStub.firstCall.args;
 

--- a/test/unit/commands/webhooks/create.test.ts
+++ b/test/unit/commands/webhooks/create.test.ts
@@ -1,0 +1,137 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { webhookFixtures } from '../../fixtures/webhooks';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks create', () => {
+  let webhooksCreateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    webhooksCreateStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      create: webhooksCreateStub,
+    }));
+
+    webhooksCreateStub.resolves(webhookFixtures.webhook1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a webhook with required flags', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--url',
+      'https://example.com/webhook',
+      '--events',
+      'token.created',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook created successfully!');
+    expect(webhooksCreateStub.calledOnce).to.be.true;
+    const [request] = webhooksCreateStub.firstCall.args;
+
+    expect(request.name).to.equal('Test Webhook');
+    expect(request.url).to.equal('https://example.com/webhook');
+    expect(request.events).to.deep.equal(['token.created']);
+  });
+
+  it('creates a webhook with multiple events', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--url',
+      'https://example.com/webhook',
+      '--events',
+      'token.created',
+      '--events',
+      'token.deleted',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook created successfully!');
+    const [request] = webhooksCreateStub.firstCall.args;
+
+    expect(request.events).to.deep.equal(['token.created', 'token.deleted']);
+  });
+
+  it('creates a webhook with notify-email', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--url',
+      'https://example.com/webhook',
+      '--events',
+      'token.created',
+      '--notify-email',
+      'test@example.com',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook created successfully!');
+    const [request] = webhooksCreateStub.firstCall.args;
+
+    expect(request.notifyEmail).to.equal('test@example.com');
+  });
+
+  it('requires name flag', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--url',
+      'https://example.com/webhook',
+      '--events',
+      'token.created',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('requires url flag', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--events',
+      'token.created',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('requires events flag', async () => {
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--url',
+      'https://example.com/webhook',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing required flag');
+  });
+
+  it('handles API errors', async () => {
+    webhooksCreateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'webhooks:create',
+      '--name',
+      'Test Webhook',
+      '--url',
+      'https://example.com/webhook',
+      '--events',
+      'token.created',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/webhooks/delete.test.ts
+++ b/test/unit/commands/webhooks/delete.test.ts
@@ -26,11 +26,7 @@ describe('webhooks delete', () => {
 
   describe('with --force flag', () => {
     it('deletes webhook without confirmation prompt', async () => {
-      const result = await runCommand([
-        'webhooks:delete',
-        'wh-1',
-        '--force',
-      ]);
+      const result = await runCommand(['webhooks:delete', 'wh-1', '--force']);
 
       expect(result.stdout).to.contain('Webhook deleted successfully!');
       expect(webhooksDeleteStub.calledOnce).to.be.true;
@@ -81,11 +77,7 @@ describe('webhooks delete', () => {
     it('handles API errors', async () => {
       webhooksDeleteStub.rejects(new Error('Webhook not found'));
 
-      const result = await runCommand([
-        'webhooks:delete',
-        'wh-1',
-        '--force',
-      ]);
+      const result = await runCommand(['webhooks:delete', 'wh-1', '--force']);
 
       expect(result.error).to.exist;
       expect(result.error!.message).to.contain('Webhook not found');

--- a/test/unit/commands/webhooks/delete.test.ts
+++ b/test/unit/commands/webhooks/delete.test.ts
@@ -1,0 +1,94 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import * as confirm from '@inquirer/confirm';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks delete', () => {
+  let confirmStub: sinon.SinonStub;
+  let webhooksDeleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    confirmStub = sinon.stub(confirm, 'default');
+    webhooksDeleteStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      delete: webhooksDeleteStub,
+    }));
+
+    webhooksDeleteStub.resolves(undefined);
+    confirmStub.resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('with --force flag', () => {
+    it('deletes webhook without confirmation prompt', async () => {
+      const result = await runCommand([
+        'webhooks:delete',
+        'wh-1',
+        '--force',
+      ]);
+
+      expect(result.stdout).to.contain('Webhook deleted successfully!');
+      expect(webhooksDeleteStub.calledOnce).to.be.true;
+      expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
+      expect(confirmStub.called).to.be.false;
+    });
+
+    it('accepts -f shorthand flag', async () => {
+      const result = await runCommand(['webhooks:delete', 'wh-1', '-f']);
+
+      expect(result.stdout).to.contain('Webhook deleted successfully!');
+      expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
+    });
+  });
+
+  describe('with confirmation prompt', () => {
+    it('deletes webhook when user confirms', async () => {
+      confirmStub.resolves(true);
+
+      const result = await runCommand(['webhooks:delete', 'wh-1']);
+
+      expect(result.stdout).to.contain('Webhook deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(webhooksDeleteStub.calledOnce).to.be.true;
+    });
+
+    it('does not delete webhook when user declines', async () => {
+      confirmStub.resolves(false);
+
+      const result = await runCommand(['webhooks:delete', 'wh-1']);
+
+      expect(result.stdout).to.not.contain('Webhook deleted successfully!');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(webhooksDeleteStub.called).to.be.false;
+    });
+  });
+
+  describe('required arguments', () => {
+    it('requires webhook id argument', async () => {
+      const result = await runCommand(['webhooks:delete']);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Missing 1 required arg');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles API errors', async () => {
+      webhooksDeleteStub.rejects(new Error('Webhook not found'));
+
+      const result = await runCommand([
+        'webhooks:delete',
+        'wh-1',
+        '--force',
+      ]);
+
+      expect(result.error).to.exist;
+      expect(result.error!.message).to.contain('Webhook not found');
+    });
+  });
+});

--- a/test/unit/commands/webhooks/delete.test.ts
+++ b/test/unit/commands/webhooks/delete.test.ts
@@ -1,15 +1,12 @@
 import { BasisTheoryClient } from '@basis-theory/node-sdk';
-import * as confirm from '@inquirer/confirm';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { runCommand } from '../../helpers/run-command';
 
 describe('webhooks delete', () => {
-  let confirmStub: sinon.SinonStub;
   let webhooksDeleteStub: sinon.SinonStub;
 
   beforeEach(() => {
-    confirmStub = sinon.stub(confirm, 'default');
     webhooksDeleteStub = sinon.stub();
 
     sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
@@ -17,51 +14,33 @@ describe('webhooks delete', () => {
     }));
 
     webhooksDeleteStub.resolves(undefined);
-    confirmStub.resolves(true);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  describe('with --force flag', () => {
-    it('deletes webhook without confirmation prompt', async () => {
-      const result = await runCommand(['webhooks:delete', 'wh-1', '--force']);
+  it('deletes webhook', async () => {
+    const result = await runCommand(['webhooks:delete', 'wh-1']);
 
-      expect(result.stdout).to.contain('Webhook deleted successfully!');
-      expect(webhooksDeleteStub.calledOnce).to.be.true;
-      expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
-      expect(confirmStub.called).to.be.false;
-    });
-
-    it('accepts -f shorthand flag', async () => {
-      const result = await runCommand(['webhooks:delete', 'wh-1', '-f']);
-
-      expect(result.stdout).to.contain('Webhook deleted successfully!');
-      expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
-    });
+    expect(result.stdout).to.contain('Webhook deleted successfully!');
+    expect(webhooksDeleteStub.calledOnce).to.be.true;
+    expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
   });
 
-  describe('with confirmation prompt', () => {
-    it('deletes webhook when user confirms', async () => {
-      confirmStub.resolves(true);
+  it('accepts --force flag', async () => {
+    const result = await runCommand(['webhooks:delete', 'wh-1', '--force']);
 
-      const result = await runCommand(['webhooks:delete', 'wh-1']);
+    expect(result.stdout).to.contain('Webhook deleted successfully!');
+    expect(webhooksDeleteStub.calledOnce).to.be.true;
+    expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
+  });
 
-      expect(result.stdout).to.contain('Webhook deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(webhooksDeleteStub.calledOnce).to.be.true;
-    });
+  it('accepts -f shorthand flag', async () => {
+    const result = await runCommand(['webhooks:delete', 'wh-1', '-f']);
 
-    it('does not delete webhook when user declines', async () => {
-      confirmStub.resolves(false);
-
-      const result = await runCommand(['webhooks:delete', 'wh-1']);
-
-      expect(result.stdout).to.not.contain('Webhook deleted successfully!');
-      expect(confirmStub.calledOnce).to.be.true;
-      expect(webhooksDeleteStub.called).to.be.false;
-    });
+    expect(result.stdout).to.contain('Webhook deleted successfully!');
+    expect(webhooksDeleteStub.calledWith('wh-1')).to.be.true;
   });
 
   describe('required arguments', () => {

--- a/test/unit/commands/webhooks/events.test.ts
+++ b/test/unit/commands/webhooks/events.test.ts
@@ -1,0 +1,43 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { eventTypesFixture } from '../../fixtures/webhooks';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks events', () => {
+  let eventsListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    eventsListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      events: {
+        list: eventsListStub,
+      },
+    }));
+
+    eventsListStub.resolves(eventTypesFixture);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists available event types', async () => {
+    const result = await runCommand(['webhooks:events']);
+
+    expect(result.stdout).to.contain('token.created');
+    expect(result.stdout).to.contain('token.deleted');
+    expect(result.stdout).to.contain('application.created');
+    expect(eventsListStub.calledOnce).to.be.true;
+  });
+
+  it('handles API errors', async () => {
+    eventsListStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['webhooks:events']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/webhooks/get.test.ts
+++ b/test/unit/commands/webhooks/get.test.ts
@@ -1,0 +1,48 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { webhookFixtures } from '../../fixtures/webhooks';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks get', () => {
+  let webhooksGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    webhooksGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      get: webhooksGetStub,
+    }));
+
+    webhooksGetStub.resolves(webhookFixtures.webhook1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gets a webhook by id', async () => {
+    const result = await runCommand(['webhooks:get', 'wh-1']);
+
+    expect(result.stdout).to.contain('wh-1');
+    expect(result.stdout).to.contain('Test Webhook');
+    expect(webhooksGetStub.calledOnce).to.be.true;
+    expect(webhooksGetStub.calledWith('wh-1')).to.be.true;
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['webhooks:get']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    webhooksGetStub.rejects(new Error('Webhook not found'));
+
+    const result = await runCommand(['webhooks:get', 'wh-invalid']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Webhook not found');
+  });
+});

--- a/test/unit/commands/webhooks/index.test.ts
+++ b/test/unit/commands/webhooks/index.test.ts
@@ -1,0 +1,50 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { webhookFixtures } from '../../fixtures/webhooks';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks', () => {
+  let webhooksListStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    webhooksListStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      list: webhooksListStub,
+    }));
+
+    webhooksListStub.resolves({ data: [webhookFixtures.webhook1] });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('lists webhooks', async () => {
+    const result = await runCommand(['webhooks']);
+
+    expect(result.stdout).to.contain('wh-1');
+    expect(result.stdout).to.contain('Test Webhook');
+    expect(result.stdout).to.contain('https://example.com/webhook');
+    expect(result.stdout).to.contain('enabled');
+    expect(webhooksListStub.calledOnce).to.be.true;
+  });
+
+  it('handles empty results', async () => {
+    webhooksListStub.resolves({ data: [] });
+
+    const result = await runCommand(['webhooks']);
+
+    expect(result.stdout).to.contain('No webhooks found.');
+  });
+
+  it('handles API errors', async () => {
+    webhooksListStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['webhooks']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/webhooks/ping.test.ts
+++ b/test/unit/commands/webhooks/ping.test.ts
@@ -1,0 +1,38 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks ping', () => {
+  let webhooksPingStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    webhooksPingStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      ping: webhooksPingStub,
+    }));
+
+    webhooksPingStub.resolves(undefined);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('sends a ping', async () => {
+    const result = await runCommand(['webhooks:ping']);
+
+    expect(result.stdout).to.contain('Webhook ping sent successfully!');
+    expect(webhooksPingStub.calledOnce).to.be.true;
+  });
+
+  it('handles API errors', async () => {
+    webhooksPingStub.rejects(new Error('API Error'));
+
+    const result = await runCommand(['webhooks:ping']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/commands/webhooks/update.test.ts
+++ b/test/unit/commands/webhooks/update.test.ts
@@ -1,0 +1,101 @@
+import { BasisTheoryClient } from '@basis-theory/node-sdk';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { webhookFixtures } from '../../fixtures/webhooks';
+import { runCommand } from '../../helpers/run-command';
+
+describe('webhooks update', () => {
+  let webhooksUpdateStub: sinon.SinonStub;
+  let webhooksGetStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    webhooksUpdateStub = sinon.stub();
+    webhooksGetStub = sinon.stub();
+
+    sinon.stub(BasisTheoryClient.prototype, 'webhooks').get(() => ({
+      get: webhooksGetStub,
+      update: webhooksUpdateStub,
+    }));
+
+    webhooksGetStub.resolves(webhookFixtures.webhook1);
+    webhooksUpdateStub.resolves(webhookFixtures.webhook1);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('updates a webhook with name', async () => {
+    const result = await runCommand([
+      'webhooks:update',
+      'wh-1',
+      '--name',
+      'Updated Webhook',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook updated successfully!');
+    expect(webhooksUpdateStub.calledOnce).to.be.true;
+    const [id, request] = webhooksUpdateStub.firstCall.args;
+
+    expect(id).to.equal('wh-1');
+    expect(request.name).to.equal('Updated Webhook');
+  });
+
+  it('updates a webhook with multiple flags', async () => {
+    const result = await runCommand([
+      'webhooks:update',
+      'wh-1',
+      '--name',
+      'Updated Webhook',
+      '--url',
+      'https://example.com/new',
+      '--events',
+      'token.created',
+      '--events',
+      'token.deleted',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook updated successfully!');
+    const [id, request] = webhooksUpdateStub.firstCall.args;
+
+    expect(id).to.equal('wh-1');
+    expect(request.name).to.equal('Updated Webhook');
+    expect(request.url).to.equal('https://example.com/new');
+    expect(request.events).to.deep.equal(['token.created', 'token.deleted']);
+  });
+
+  it('updates a webhook with notify-email', async () => {
+    const result = await runCommand([
+      'webhooks:update',
+      'wh-1',
+      '--notify-email',
+      'new@example.com',
+    ]);
+
+    expect(result.stdout).to.contain('Webhook updated successfully!');
+    const [, request] = webhooksUpdateStub.firstCall.args;
+
+    expect(request.notifyEmail).to.equal('new@example.com');
+  });
+
+  it('requires id argument', async () => {
+    const result = await runCommand(['webhooks:update']);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('Missing 1 required arg');
+  });
+
+  it('handles API errors', async () => {
+    webhooksUpdateStub.rejects(new Error('API Error'));
+
+    const result = await runCommand([
+      'webhooks:update',
+      'wh-1',
+      '--name',
+      'Updated',
+    ]);
+
+    expect(result.error).to.exist;
+    expect(result.error!.message).to.contain('API Error');
+  });
+});

--- a/test/unit/fixtures/account-updater.ts
+++ b/test/unit/fixtures/account-updater.ts
@@ -1,0 +1,24 @@
+export const accountUpdaterFixtures = {
+  job1: {
+    id: 'job-1',
+    status: 'pending',
+    uploadUrl: 'https://example.com/upload',
+    createdAt: '2024-01-01T00:00:00Z',
+    expiresAt: '2024-01-02T00:00:00Z',
+  },
+  job2: {
+    id: 'job-2',
+    status: 'completed',
+    createdAt: '2024-01-03T00:00:00Z',
+    expiresAt: '2024-01-04T00:00:00Z',
+  },
+  realTimeResponse: {
+    tokenId: 'tok-1',
+    status: 'updated',
+    currentToken: {
+      number: '4242424242424242',
+      expirationMonth: 12,
+      expirationYear: 2025,
+    },
+  },
+};

--- a/test/unit/fixtures/apple-pay.ts
+++ b/test/unit/fixtures/apple-pay.ts
@@ -1,0 +1,42 @@
+export const applePayTokenFixture = {
+  id: 'ap-1',
+  tenantId: 't1',
+  tokenId: 'tok-1',
+  expiresAt: '2025-12-31T00:00:00.000Z',
+  merchantRegistrationId: 'mr-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+export const applePayCreateResponseFixture = {
+  id: 'ap-1',
+  tokenId: 'tok-1',
+  expiresAt: '2025-12-31T00:00:00.000Z',
+};
+
+export const applePaySessionFixture = {
+  merchantSessionIdentifier: 'session-123',
+  displayName: 'Test Store',
+  domainName: 'example.com',
+};
+
+export const applePayDomainFixture = {
+  domains: ['example.com', 'shop.example.com'],
+};
+
+export const applePayDomainRegisterFixture = {
+  domains: ['example.com'],
+};
+
+export const applePayMerchantFixture = {
+  id: 'merch-1',
+  merchantIdentifier: 'merchant.com.example',
+  tenantId: 't1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+export const applePayMerchantCertificatesFixture = {
+  id: 'cert-1',
+  merchantId: 'merch-1',
+  domain: 'example.com',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};

--- a/test/unit/fixtures/documents.ts
+++ b/test/unit/fixtures/documents.ts
@@ -1,0 +1,28 @@
+const testDate = new Date('2024-01-01T00:00:00Z');
+
+const DOCUMENT_ID = 'd1e2f3a4-b5c6-7890-abcd-ef1234567890';
+
+const documentFixtures = {
+  basic: {
+    id: DOCUMENT_ID,
+    filename: 'test-document.pdf',
+    contentType: 'application/pdf',
+    size: 1024,
+    createdAt: testDate,
+    modifiedAt: testDate,
+  },
+  withMetadata: {
+    id: DOCUMENT_ID,
+    filename: 'test-document.pdf',
+    contentType: 'application/pdf',
+    size: 1024,
+    metadata: {
+      category: 'reports',
+      owner: 'test-user',
+    },
+    createdAt: testDate,
+    modifiedAt: testDate,
+  },
+};
+
+export { documentFixtures, DOCUMENT_ID };

--- a/test/unit/fixtures/enrichments.ts
+++ b/test/unit/fixtures/enrichments.ts
@@ -1,0 +1,9 @@
+export const enrichmentFixtures = {
+  bankVerification: {
+    status: 'verified',
+    details: {
+      bankName: 'Test Bank',
+      routingNumber: '021000021',
+    },
+  },
+};

--- a/test/unit/fixtures/google-pay.ts
+++ b/test/unit/fixtures/google-pay.ts
@@ -1,0 +1,27 @@
+export const googlePayTokenFixture = {
+  id: 'gp-1',
+  tenantId: 't1',
+  tokenId: 'tok-1',
+  expiresAt: '2025-12-31T00:00:00.000Z',
+  merchantRegistrationId: 'mr-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+export const googlePayCreateResponseFixture = {
+  id: 'gp-1',
+  tokenId: 'tok-1',
+  expiresAt: '2025-12-31T00:00:00.000Z',
+};
+
+export const googlePayMerchantFixture = {
+  id: 'merch-1',
+  merchantIdentifier: 'merchant.com.example',
+  tenantId: 't1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+export const googlePayMerchantCertificatesFixture = {
+  id: 'cert-1',
+  merchantId: 'merch-1',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};

--- a/test/unit/fixtures/keys.ts
+++ b/test/unit/fixtures/keys.ts
@@ -1,0 +1,16 @@
+export const keyMetadataFixtures = [
+  {
+    keyId: 'key-1',
+    expiresAt: new Date('2025-01-01'),
+  },
+  {
+    keyId: 'key-2',
+    expiresAt: new Date('2025-06-01'),
+  },
+];
+
+export const keyResponseFixture = {
+  keyId: 'key-new',
+  publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBg...\n-----END PUBLIC KEY-----',
+  expiresAt: new Date('2025-12-31'),
+};

--- a/test/unit/fixtures/keys.ts
+++ b/test/unit/fixtures/keys.ts
@@ -11,6 +11,7 @@ export const keyMetadataFixtures = [
 
 export const keyResponseFixture = {
   keyId: 'key-new',
-  publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBg...\n-----END PUBLIC KEY-----',
+  publicKeyPem:
+    '-----BEGIN PUBLIC KEY-----\nMIIBIjANBg...\n-----END PUBLIC KEY-----',
   expiresAt: new Date('2025-12-31'),
 };

--- a/test/unit/fixtures/logs.ts
+++ b/test/unit/fixtures/logs.ts
@@ -1,0 +1,17 @@
+export const logFixtures = [
+  {
+    tenantId: 't1',
+    actorId: 'a1',
+    actorType: 'application',
+    entityType: 'token',
+    entityId: 'e1',
+    operation: 'read',
+    message: 'Token retrieved',
+    createdAt: new Date('2024-01-01'),
+  },
+];
+
+export const entityTypeFixtures = [
+  { displayName: 'Application', value: 'application' },
+  { displayName: 'Token', value: 'token' },
+];

--- a/test/unit/fixtures/logs.ts
+++ b/test/unit/fixtures/logs.ts
@@ -12,6 +12,12 @@ export const logFixtures = [
 ];
 
 export const entityTypeFixtures = [
-  { displayName: 'Application', value: 'application' },
-  { displayName: 'Token', value: 'token' },
+  {
+    displayName: 'Application',
+    value: 'application',
+  },
+  {
+    displayName: 'Token',
+    value: 'token',
+  },
 ];

--- a/test/unit/fixtures/network-tokens.ts
+++ b/test/unit/fixtures/network-tokens.ts
@@ -1,0 +1,22 @@
+export const networkTokenFixtures = {
+  networkToken1: {
+    id: 'nt-1',
+    tenantId: 't1',
+    tokenId: 'tok-1',
+    status: 'active',
+    network: 'visa',
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  networkToken2: {
+    id: 'nt-2',
+    tenantId: 't1',
+    tokenId: 'tok-2',
+    status: 'suspended',
+    network: 'mastercard',
+    createdAt: '2024-01-02T00:00:00Z',
+  },
+  cryptogram: {
+    cryptogram: 'abc123cryptogram',
+    eci: '05',
+  },
+};

--- a/test/unit/fixtures/tenants.ts
+++ b/test/unit/fixtures/tenants.ts
@@ -1,0 +1,77 @@
+const testDate = new Date('2024-01-01T00:00:00Z');
+
+export const tenantFixture = {
+  id: 'tenant-1',
+  ownerId: 'owner-1',
+  name: 'Test Tenant',
+  type: 'production',
+  settings: {
+    fingerprintTokens: 'enabled',
+    deduplicateTokens: 'disabled',
+    disableEphemeralProxy: 'disabled',
+  },
+  createdAt: testDate,
+};
+
+export const tenantUsageReportFixture = {
+  tokenReport: {
+    metricsByType: [
+      {
+        type: 'token',
+        count: 100,
+        lastCreatedAt: testDate,
+      },
+    ],
+  },
+};
+
+export const tenantMemberFixtures = [
+  {
+    id: 'member-1',
+    user: {
+      id: 'user-1',
+      email: 'admin@example.com',
+    },
+    role: 'ADMIN',
+    createdAt: testDate,
+  },
+  {
+    id: 'member-2',
+    user: {
+      id: 'user-2',
+      email: 'member@example.com',
+    },
+    role: 'MEMBER',
+    createdAt: testDate,
+  },
+];
+
+export const tenantInvitationFixtures = [
+  {
+    id: 'inv-1',
+    email: 'invite1@example.com',
+    role: 'ADMIN',
+    status: 'PENDING',
+    createdAt: testDate,
+  },
+  {
+    id: 'inv-2',
+    email: 'invite2@example.com',
+    role: 'MEMBER',
+    status: 'PENDING',
+    createdAt: testDate,
+  },
+];
+
+export const tenantMerchantFixtures = [
+  {
+    id: 'merchant-1',
+    name: 'Test Merchant 1',
+    createdAt: testDate,
+  },
+  {
+    id: 'merchant-2',
+    name: 'Test Merchant 2',
+    createdAt: testDate,
+  },
+];

--- a/test/unit/fixtures/threeds.ts
+++ b/test/unit/fixtures/threeds.ts
@@ -1,0 +1,24 @@
+export const threedsFixtures = {
+  session1: {
+    id: 'sess-1',
+    tenantId: 't1',
+    tokenId: 'tok-1',
+    type: 'browser',
+    status: 'created',
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  authentication1: {
+    id: 'auth-1',
+    sessionId: 'sess-1',
+    status: 'successful',
+    authenticationValue: 'abc123',
+    eci: '05',
+  },
+  challengeResult1: {
+    id: 'auth-1',
+    sessionId: 'sess-1',
+    status: 'successful',
+    authenticationValue: 'abc123',
+    eci: '05',
+  },
+};

--- a/test/unit/fixtures/token-intents.ts
+++ b/test/unit/fixtures/token-intents.ts
@@ -1,0 +1,32 @@
+import type { BasisTheory } from '@basis-theory/node-sdk';
+
+const testDate = new Date('2024-01-01T00:00:00Z');
+
+export const tokenIntentFixtures: Record<string, BasisTheory.TokenIntent> = {
+  card1: {
+    id: 'ti-1',
+    type: 'card',
+    tenantId: 't1',
+    card: {
+      bin: '424242',
+      last4: '4242',
+      expirationMonth: 12,
+      expirationYear: 2025,
+    },
+    createdAt: testDate,
+  },
+};
+
+export const createTokenIntentResponse: BasisTheory.CreateTokenIntentResponse =
+  {
+    id: 'ti-1',
+    type: 'card',
+    tenantId: 't1',
+    card: {
+      bin: '424242',
+      last4: '4242',
+      expirationMonth: 12,
+      expirationYear: 2025,
+    },
+    createdAt: testDate,
+  };

--- a/test/unit/fixtures/tokens.ts
+++ b/test/unit/fixtures/tokens.ts
@@ -18,7 +18,9 @@ export const tokenFixtures: Record<string, BasisTheory.Token> = {
     tenantId: 't1',
     data: {
       number: '4242...4242',
+      // eslint-disable-next-line camelcase
       expiration_month: 12,
+      // eslint-disable-next-line camelcase
       expiration_year: 2025,
     },
     containers: ['/pci/high/'],

--- a/test/unit/fixtures/tokens.ts
+++ b/test/unit/fixtures/tokens.ts
@@ -1,0 +1,27 @@
+import type { BasisTheory } from '@basis-theory/node-sdk';
+
+const testDate = new Date('2024-01-01T00:00:00Z');
+
+export const tokenFixtures: Record<string, BasisTheory.Token> = {
+  token1: {
+    id: 'tok-1',
+    type: 'token',
+    tenantId: 't1',
+    data: 'secret',
+    containers: ['/general/high/'],
+    createdAt: testDate,
+    fingerprintExpression: '{{ data }}',
+  },
+  card1: {
+    id: 'tok-2',
+    type: 'card',
+    tenantId: 't1',
+    data: {
+      number: '4242...4242',
+      expiration_month: 12,
+      expiration_year: 2025,
+    },
+    containers: ['/pci/high/'],
+    createdAt: testDate,
+  },
+};

--- a/test/unit/fixtures/webhooks.ts
+++ b/test/unit/fixtures/webhooks.ts
@@ -1,0 +1,17 @@
+export const webhookFixtures = {
+  webhook1: {
+    id: 'wh-1',
+    name: 'Test Webhook',
+    url: 'https://example.com/webhook',
+    status: 'enabled',
+    events: ['token.created'],
+    tenantId: 't1',
+    createdAt: new Date('2024-01-01'),
+  },
+};
+
+export const eventTypesFixture = [
+  'token.created',
+  'token.deleted',
+  'application.created',
+];


### PR DESCRIPTION
## Description

Major version bump to v4.0.0. Adds all public Basis Theory API endpoints to the CLI, removes interactive prompts in favor of pure CLI-driven flags, adds config file support, and flags beta endpoints.

### Changes

- **All public endpoints added**: tokens, token intents, documents, webhooks, keys, logs, tenants (members, invitations, merchants), applications, reactors, proxies, account updater, network tokens, 3DS, enrichments, Apple Pay, Google Pay, connections (Stripe Forward)
- **Config file support** (`~/.basistheory/cli.json`): API keys can be provided via config file instead of env vars or flags. File is auto-created on first run. Supports `apiKey`, `managementApiKey`, and `apiBaseUrl`
- **Interactive prompts removed**: All commands are now purely flag-driven. No `@inquirer` dependencies used at runtime. Commands that previously required interactive selection (applications/reactors/proxies list) now output tables directly
- **Beta endpoints flagged**: `[Beta]` prefix on topic descriptions for: enrichments, 3DS, network-tokens, apple-pay, google-pay
- **Fixed tenant merchants endpoint**: Changed from `/tenants/self/merchants` to `/tenants/{id}/merchants` per API docs
- **Fixed non-null assertion warnings**: Replaced `!` assertions with proper null checks in `tokenize.ts` and `invoke.ts`
- **Management key no longer required flag**: Can come from config file, so oclif `required: true` removed

### Breaking Changes

- `management-key` is no longer a required flag (can be provided via config file)
- Interactive prompts removed — all values must be provided via flags
- `bt applications`, `bt reactors`, `bt proxies` now output a table instead of an interactive picker
- `bt reactors logs` and `bt proxies logs` now require the `id` argument (was previously optional with interactive fallback)

## Endpoint Test Results (`scripts/test-endpoints.sh`)

**49 passed, 0 failed, 12 skipped**

### Passing (49)

| Category | Commands Tested | Status |
|----------|----------------|--------|
| Config File | directory exists, file exists, valid JSON | :white_check_mark: Pass |
| Tenants | `get`, `usage`, `update` | :white_check_mark: Pass |
| Tenant Members | `list`, `list --page 1 --size 5` | :white_check_mark: Pass |
| Tenant Invitations | `list`, `create` | :white_check_mark: Pass |
| Tenant Merchants | `list` | :white_check_mark: Pass |
| Logs | `list`, `list --entity-type`, `entity-types` | :white_check_mark: Pass |
| Webhooks | `list`, `events`, `create`, `get`, `update`, `ping`, `delete` | :white_check_mark: Pass |
| Client Keys | `list`, `create`, `delete` | :white_check_mark: Pass |
| Tokens | `create`, `list`, `types`, `get`, `update`, `search`, `delete` | :white_check_mark: Pass |
| Tokenize / Detokenize | `tokenize`, `detokenize` | :white_check_mark: Pass |
| Token Intents | `create`, `get`, `delete` | :white_check_mark: Pass |
| Documents | `upload`, `get`, `download`, `delete` | :white_check_mark: Pass |
| Invoke Reactors | `create` (test reactor), `invoke` (sync) , `delete` | :white_check_mark: Pass |
| Invoke Proxies | `invoke` (ephemeral) | :white_check_mark: Pass |
| Account Updater | `jobs list`, `jobs create`, `jobs get` | :white_check_mark: Pass |
| Management Listings | `applications`, `reactors`, `proxies` | :white_check_mark: Pass |

### Skipped (12) — With Reasons

| Test | Reason | Category |
|------|--------|----------|
| Config file read test | `BT_MANAGEMENT_KEY` not in env (keys provided via config file) | Config |
| Account updater real-time | Requires `AU_TOKEN_ID` env var (valid card token needed) | Needs test data |
| Network tokens (2 tests) | Requires `NT_TOKEN_ID` env var (valid card token needed) | **Beta** |
| 3DS sessions (2 tests) | Requires `THREEDS_TOKEN_ID` env var (valid card token/intent needed) | **Beta** |
| Enrichments (1 test) | Requires `BANK_TOKEN_ID` env var (valid bank token needed) | **Beta** |
| Apple Pay (3 tests) | Requires `apple-pay:manage` permission (management key type only) | **Beta** |
| Google Pay (1 test) | Requires `google-pay:manage` permission (management key type only) | **Beta** |
| Stripe Forward (1 test) | Requires `STRIPE_FORWARD_TEST=true` and configured Stripe connection | Needs setup |

**Beta endpoint skips**: Network tokens, 3DS, enrichments, Apple Pay, and Google Pay are flagged as `[Beta]` in the CLI topic descriptions. These endpoints require either specialized test data (card tokens, bank tokens) or management-only permissions (`apple-pay:manage`, `google-pay:manage`) that the test private API key cannot have. These are correctly skipped rather than failed — the CLI wiring is in place and the SDK calls are correct.

**Permission skips**: Apple Pay domain/merchant and Google Pay merchant operations require a **management** application key with specific permissions. The test uses a private API key which cannot be granted `apple-pay:manage` or `google-pay:manage` per the Basis Theory permissions model. The test script auto-detects 403 responses and marks them as `SKIP (missing permission)` instead of failures.

### Unit Tests

**436 passing, 0 failing**

## Testing required outside of automated testing?

- [x] Not Applicable — `scripts/test-endpoints.sh` covers all endpoints with live API calls

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change